### PR TITLE
Added setAccessToken to fix 401 mapbox error

### DIFF
--- a/myApp/app/__tests__/IndoorMapTests/IndoorMap.tests.js
+++ b/myApp/app/__tests__/IndoorMapTests/IndoorMap.tests.js
@@ -1,8 +1,10 @@
 import React from "react";
 import { render, waitFor } from "@testing-library/react-native";
 import IndoorMap from "../../components/IndoorMap/IndoorMap";
+import { setAccessToken } from "@rnmapbox/maps";
 
 jest.mock("@rnmapbox/maps", () => ({
+  setAccessToken: jest.fn(),
   ShapeSource: jest.fn(() => null),
   FillLayer: jest.fn(() => null),
   LineLayer: jest.fn(() => null),

--- a/myApp/app/components/IndoorMap/IndoorMap.js
+++ b/myApp/app/components/IndoorMap/IndoorMap.js
@@ -8,6 +8,8 @@ const IndoorMap = ({ selectedBuilding, selectedFloor }) => {
   const MAPBOX_ACCESS_TOKEN = Constants.expoConfig?.extra?.mapbox;
   const DATASET_ID = "cm7qjtnoy2d3o1qmmngcrv0jl";
 
+  Mapbox.setAccessToken(MAPBOX_ACCESS_TOKEN);
+
   useEffect(() => {
     const fetchGeoJson = async () => {
       try {


### PR DESCRIPTION
This pull request includes a small change to the `IndoorMap` component in the `myApp/app/components/IndoorMap/IndoorMap.js` file. The change sets the Mapbox access token using `Mapbox.setAccessToken` with the `MAPBOX_ACCESS_TOKEN` value. This fixes `Mapbox [error] MapLoad error Failed to load tile: HTTP status code 401`. closes #252