### PR TITLE
Indoor directions route for disabled

### DIFF
--- a/myApp/app/(tabs)/map.jsx
+++ b/myApp/app/(tabs)/map.jsx
@@ -70,6 +70,9 @@ export default function MapView() {
   const [activeCampus, setActiveCampus] = useState(type);
   const mapRef = useRef(null);
 
+  // Disabled on or off
+  const [isDisabled, setIsDisabled] = useState(false);
+
   // Location & permissions
   const { location, hasPermission } = useLocation();
   const [showPermissionPopup, setShowPermissionPopup] =
@@ -849,6 +852,7 @@ export default function MapView() {
             startNode={originText}
             endNode={destinationText}
             currentFloor={selectedFloor}
+            isDisabled={isDisabled}
           />
 
           {/* POI Markers */}

--- a/myApp/app/(tabs)/map.jsx
+++ b/myApp/app/(tabs)/map.jsx
@@ -24,7 +24,10 @@ import IndoorMap from "../components/IndoorMap/IndoorMap";
 import FloorNavigation from "../components/FloorNavigation";
 import MapDirections from "../components/MapDirections";
 import ShortestPathMap from "../components/IndoorMap/ShortestPathMap";
-import { graph, nodeCoordinates } from "../components/IndoorMap/GraphAndCoordinates/GraphAndCoordinates";
+import { hGraph, hNodeCoordinates } from "../components/IndoorMap/GraphAndCoordinates/Hall";
+import { ccGraph, ccNodeCoordinates } from "../components/IndoorMap/GraphAndCoordinates/CC";
+import { loyolaGraph, loyolaNodeCoordinates } from "../components/IndoorMap/GraphAndCoordinates/Loyola";
+import { mbGraph, mbNodeCoordinates } from "../components/IndoorMap/GraphAndCoordinates/MB";
 import {
   handleIndoorBuildingSelect,
   handleClearIndoorMap,
@@ -71,7 +74,7 @@ export default function MapView() {
   const mapRef = useRef(null);
 
   // Disabled on or off
-  const [isDisabled, setIsDisabled] = useState(false);
+  const [isDisabled, setIsDisabled] = useState(true);
 
   // Location & permissions
   const { location, hasPermission } = useLocation();
@@ -125,6 +128,10 @@ export default function MapView() {
     "Loyola Campus": { latitude: 45.4582, longitude: -73.6405 },
     "Montreal Downtown": { latitude: 45.5017, longitude: -73.5673 },
   };
+
+  // Combine Graphs and Coordinates
+  const graph = { ...hGraph, ...mbGraph, ...ccGraph, ...loyolaGraph};
+  const nodeCoordinates = { ...hNodeCoordinates, ...mbNodeCoordinates, ...ccNodeCoordinates, ...loyolaNodeCoordinates};
 
   // Track selected floor
   const [selectedFloor, setSelectedFloor] = useState(null);

--- a/myApp/app/(tabs)/map.jsx
+++ b/myApp/app/(tabs)/map.jsx
@@ -74,7 +74,7 @@ export default function MapView() {
   const mapRef = useRef(null);
 
   // Disabled on or off
-  const [isDisabled, setIsDisabled] = useState(true);
+  const [isDisabled, setIsDisabled] = useState(false);
 
   // Location & permissions
   const { location, hasPermission } = useLocation();

--- a/myApp/app/__tests__/IndoorMapTests/Algorithm.test.js
+++ b/myApp/app/__tests__/IndoorMapTests/Algorithm.test.js
@@ -1,0 +1,32 @@
+import { dijkstra } from "../../components/IndoorMap/ShortestPath";
+
+describe("Dijkstra's Algorithm with Disabled Option", () => {
+  const graph = {
+    "A": { "B": 1, "stair-C": 1, "path-D-stairs": 2, "elevator-E": 3 },
+    "B": { "A": 1, "C": 1 },
+    "C": { "B": 1, "D": 2 },
+    "D": { "C": 2, "E": 1 },
+    "E": { "D": 1, "F": 3 },
+    "F": { "E": 3 },
+    "stair-C": { "A": 1, "D": 2 }, // Should be skipped if isDisabled is true
+    "escalator-F": { "E": 1 }, // Should be skipped if isDisabled is true
+    "path-D-stairs": { "A": 2, "D": 1 }, // Should NOT be skipped
+    "elevator-E": { "A": 3, "E": 2 } // Should NOT be skipped
+  };
+
+  it("finds the shortest path normally (without disabling stairs/escalators)", () => {
+    const result = dijkstra(graph, "A", "F", false);
+    expect(result).toEqual(["A", "stair-C", "D", "E", "F"]);
+  });
+
+  it("avoids stairs/escalators when isDisabled is true", () => {
+    const result = dijkstra(graph, "A", "F", true);
+    expect(result).toEqual(["A", "path-D-stairs", "D", "E", "F"]);
+  });
+
+  it("includes paths and elevators even when isDisabled is true", () => {
+    const result = dijkstra(graph, "A", "E", true);
+    expect(result).toEqual(["A", "path-D-stairs", "D", "E"]);
+  });
+
+});

--- a/myApp/app/__tests__/IndoorMapTests/Algorithm.test.js
+++ b/myApp/app/__tests__/IndoorMapTests/Algorithm.test.js
@@ -11,7 +11,13 @@ describe("Dijkstra's Algorithm with Disabled Option", () => {
     "stair-C": { "A": 1, "D": 2 }, // Should be skipped if isDisabled is true
     "escalator-F": { "E": 1 }, // Should be skipped if isDisabled is true
     "path-D-stairs": { "A": 2, "D": 1 }, // Should NOT be skipped
-    "elevator-E": { "A": 3, "E": 2 } // Should NOT be skipped
+    "elevator-E": { "A": 3, "E": 2 }, // Should NOT be skipped
+    "W": {"stair-Z": 1},
+    "stair-Z": {"Z": 1},
+    "Z": {"stair-Z": 1},
+    "T": {"escalator-Y": 1},
+    "escalator-Y": {"Y": 1},
+    "Y": {"escalator-Y": 1},
   };
 
   it("finds the shortest path normally (without disabling stairs/escalators)", () => {
@@ -28,5 +34,20 @@ describe("Dijkstra's Algorithm with Disabled Option", () => {
     const result = dijkstra(graph, "A", "E", true);
     expect(result).toEqual(["A", "path-D-stairs", "D", "E"]);
   });
+
+  it("returns null if a node is inacessible while isDisabled is set to true", () => {
+    const result = dijkstra(graph, "W", "Z", true);
+    expect(result).toBeNull();
+  });
+
+  it("returns null if start node is a stair", () => {
+    const result = dijkstra(graph, "stair-Z", "Z", true);
+    expect(result).toBeNull();
+  });
+
+  it ("returns null if the end node is an escalator", () => {
+    const result = dijkstra(graph, "Y", "escalator-Y", true);
+    expect(result).toBeNull();
+  })
 
 });

--- a/myApp/app/components/IndoorMap/GraphAndCoordinates/CC.js
+++ b/myApp/app/components/IndoorMap/GraphAndCoordinates/CC.js
@@ -1,0 +1,385 @@
+export const ccGraph = {
+    "path-CC111-CC112": {
+      "CC111": 2,
+      "CC112": 2,
+      "path-CC109": 7,
+      "path-CC115-CC116": 11
+    },
+    "path-stairs1": {
+      "CCStairs1": 2,
+      "path-CC117-stairs1": 6
+    },
+    "CC122": {
+      "path-CC122": 2
+    },
+    "CCWashroom2": {},
+    "path-CC150": {
+      "CCStairs3": 2,
+      "path-CC104": 3,
+      "CCExit": 5
+    },
+    "path-CC107-CC109": {
+      "path-CC109": 2,
+      "path-elevator1": 3,
+      "path-CC107": 2
+    },
+    "CCStairs3": {
+      "path-CC150": 2
+    },
+    "path-stairs2": {
+      "CCStairs2": 3,
+      "path-elevator1": 5
+    },
+    "path-CC117": {
+      "CC117": 2,
+      "path-CC120": 4,
+      "path-CC117-stairs1": 1
+    },
+    "CC106": {
+      "path-CC101-CC106": 2
+    },
+    "path-CC104": {
+      "path-CC150": 3,
+      "path-CC101-CC106": 5
+    },
+    "path-CC119-CC124": {
+      "CC119": 2,
+      "path-CC122": 9,
+      "CCWashroom1": 2
+    },
+    "path-CC117-stairs1": {
+      "path-CC117": 1,
+      "path-stairs1": 6,
+      "path-CC115-CC116": 8
+    },
+    "path-CC109": {
+      "path-CC107-CC109": 2,
+      "CC109": 2,
+      "path-CC111-CC112": 7
+    },
+    "CC115": {
+      "path-CC115-CC116": 2
+    },
+    "CC107": {
+      "path-CC107": 1
+    },
+    "CC109": {
+      "path-CC109": 2
+    },
+    "CCStairs2": {
+      "path-stairs2": 3
+    },
+    "path-elevator1": {
+      "path-CC107-CC109": 3,
+      "path-stairs2": 5,
+      "CCElevator1": 3
+    },
+    "path-CC120": {
+      "path-CC117": 4,
+      "CC120": 2,
+      "path-CC122": 8
+    },
+    "CC116": {
+      "path-CC115-CC116": 2
+    },
+    "path-CC107": {
+      "path-CC107-CC109": 2,
+      "CC107": 1,
+      "path-CC101-CC106": 10
+    },
+    "CC117": {
+      "path-CC117": 2
+    },
+    "CCElevator1": {
+      "path-elevator1": 3
+    },
+    "path-CC101-CC106": {
+      "CC106": 2,
+      "path-CC104": 5,
+      "CC101": 2,
+      "path-CC107": 10
+    },
+    "CCExit": {
+      "path-CC150": 5
+    },
+    "CC101": {
+      "path-CC101-CC106": 2
+    },
+    "CCStairs1": {
+      "path-stairs1": 2
+    },
+    "CCWashroom1": {
+      "path-CC119-CC124": 2
+    },
+    "path-CC115-CC116": {
+      "CC115": 2,
+      "CC116": 2,
+      "path-CC117-stairs1": 8,
+      "path-CC111-CC112": 11
+    },
+    "CC119": {
+      "path-CC119-CC124": 2
+    },
+    "CC111": {
+      "path-CC111-CC112": 2
+    },
+    "CC120": {
+      "path-CC120": 2
+    },
+    "CC112": {
+      "path-CC111-CC112": 2
+    },
+    "path-CC122": {
+      "CC122": 2,
+      "path-CC119-CC124": 9,
+      "path-CC120": 8
+    }
+  }
+  
+  export const ccNodeCoordinates = {
+    "path-CC111-CC112": {
+      "coordinates": [
+        -73.64027,
+        45.458185
+      ],
+      "floor": 1
+    },
+    "path-stairs1": {
+      "coordinates": [
+        -73.640443,
+        45.458312
+      ],
+      "floor": 1
+    },
+    "CC122": {
+      "coordinates": [
+        -73.640623,
+        45.458339
+      ],
+      "floor": 1
+    },
+    "CCWashroom2": {
+      "coordinates": [
+        -73.639983,
+        45.458092
+      ],
+      "floor": 2
+    },
+    "path-CC150": {
+      "coordinates": [
+        -73.639958,
+        45.458064
+      ],
+      "floor": 1
+    },
+    "path-CC107-CC109": {
+      "coordinates": [
+        -73.640173,
+        45.458148
+      ],
+      "floor": 1
+    },
+    "CCStairs3": {
+      "coordinates": [
+        -73.639972,
+        45.458046
+      ],
+      "floor": 3
+    },
+    "path-stairs2": {
+      "coordinates": [
+        -73.640125,
+        45.458208
+      ],
+      "floor": 2
+    },
+    "path-CC117": {
+      "coordinates": [
+        -73.640495,
+        45.458273
+      ],
+      "floor": 1
+    },
+    "CC106": {
+      "coordinates": [
+        -73.640035,
+        45.458111
+      ],
+      "floor": 1
+    },
+    "path-CC104": {
+      "coordinates": [
+        -73.639993,
+        45.458078
+      ],
+      "floor": 1
+    },
+    "path-CC119-CC124": {
+      "coordinates": [
+        -73.640729,
+        45.458363
+      ],
+      "floor": 1
+    },
+    "path-CC117-stairs1": {
+      "coordinates": [
+        -73.640479,
+        45.458266
+      ],
+      "floor": 1
+    },
+    "path-CC109": {
+      "coordinates": [
+        -73.640194,
+        45.458156
+      ],
+      "floor": 1
+    },
+    "CC115": {
+      "coordinates": [
+        -73.640402,
+        45.458216
+      ],
+      "floor": 1
+    },
+    "CC107": {
+      "coordinates": [
+        -73.640161,
+        45.458132
+      ],
+      "floor": 1
+    },
+    "CC109": {
+      "coordinates": [
+        -73.640207,
+        45.458141
+      ],
+      "floor": 1
+    },
+    "CCStairs2": {
+      "coordinates": [
+        -73.64016,
+        45.458221
+      ],
+      "floor": 2
+    },
+    "path-elevator1": {
+      "coordinates": [
+        -73.640154,
+        45.458172
+      ],
+      "floor": 1
+    },
+    "path-CC120": {
+      "coordinates": [
+        -73.640545,
+        45.458292
+      ],
+      "floor": 1
+    },
+    "CC116": {
+      "coordinates": [
+        -73.640379,
+        45.458245
+      ],
+      "floor": 1
+    },
+    "path-CC107": {
+      "coordinates": [
+        -73.640155,
+        45.458141
+      ],
+      "floor": 1
+    },
+    "CC117": {
+      "coordinates": [
+        -73.640509,
+        45.458257
+      ],
+      "floor": 1
+    },
+    "CCElevator1": {
+      "coordinates": [
+        -73.640126,
+        45.458161
+      ],
+      "floor": 1
+    },
+    "path-CC101-CC106": {
+      "coordinates": [
+        -73.640045,
+        45.458098
+      ],
+      "floor": 1
+    },
+    "CCExit": {
+      "coordinates": [
+        -73.639906,
+        45.458045
+      ],
+      "floor": 0
+    },
+    "CC101": {
+      "coordinates": [
+        -73.640058,
+        45.458081
+      ],
+      "floor": 1
+    },
+    "CCStairs1": {
+      "coordinates": [
+        -73.64042,
+        45.458303
+      ],
+      "floor": 1
+    },
+    "CCWashroom1": {
+      "coordinates": [
+        -73.64072,
+        45.458376
+      ],
+      "floor": 1
+    },
+    "path-CC115-CC116": {
+      "coordinates": [
+        -73.640388,
+        45.458231
+      ],
+      "floor": 1
+    },
+    "CC119": {
+      "coordinates": [
+        -73.640742,
+        45.458348
+      ],
+      "floor": 1
+    },
+    "CC111": {
+      "coordinates": [
+        -73.640282,
+        45.45817
+      ],
+      "floor": 1
+    },
+    "CC120": {
+      "coordinates": [
+        -73.640535,
+        45.458306
+      ],
+      "floor": 1
+    },
+    "CC112": {
+      "coordinates": [
+        -73.64026,
+        45.458199
+      ],
+      "floor": 1
+    },
+    "path-CC122": {
+      "coordinates": [
+        -73.640632,
+        45.458326
+      ],
+      "floor": 1
+    }
+  }

--- a/myApp/app/components/IndoorMap/GraphAndCoordinates/Hall.js
+++ b/myApp/app/components/IndoorMap/GraphAndCoordinates/Hall.js
@@ -1,0 +1,3436 @@
+export const hGraph = {
+  "path-H961.33": {
+    "H961.33": 1,
+    "path-H961.41": 2,
+    "path-H943": 1
+  },
+  "path-H937.1": {
+    "H937.1": 5,
+    "path-H966.1": 5,
+    "path-H937.1.2": 6,
+    "path-H985": 8,
+    "path-DownH9escalator": 5
+  },
+  "path-H805.2-3": {
+    "H805.3": 1,
+    "H805.2": 1,
+    "path-H805.1-2-3": 3
+  },
+  "H827": {
+    "path-H827": 3
+  },
+  "H927.1": {
+    "path-H927.1": 20,
+    "H927.3": 4
+  },
+  "H966": {
+    "path-H966": 1
+  },
+  "path_hivecafe": {
+    "hive-cafe": 9,
+    "path-escalatorup1H2": 13
+  },
+  "H280": {
+    "path-H280.2": 7
+  },
+  "path-H849": {
+    "path-H847": 2,
+    "H849": 4,
+    "path-H853": 5
+  },
+  "H841": {
+    "path-H841": 3
+  },
+  "path-H933.11": {
+    "H933.11": 1,
+    "path-H937": 7,
+    "path-H932": 2
+  },
+  "path-H961.27": {
+    "H961.27": 1,
+    "path-H961.28": 1,
+    "path-H961.25": 4
+  },
+  "path-H1stairs2": {
+    "path-H1stairs1": 5,
+    "elevatorH2": 18,
+    "stairs2H1": 9,
+    "elevatorH1": 12
+  },
+  "path-H1.2-Hall-principal-entrance": {
+    "Hall-principal-entrance": 8,
+    "path-principalEntrance": 23
+  },
+  "H961.3": {
+    "path-H961.3": 1
+  },
+  "path-H927": {
+    "H927": 1,
+    "path-H928": 4,
+    "path-H927.4.2": 7
+  },
+  "H964.2": {
+    "H964.1": 4,
+    "H964.3": 2
+  },
+  "H915": {
+    "path-H915": 3
+  },
+  "H990": {
+    "path-H990": 1
+  },
+  "H859": {
+    "path-H859": 2
+  },
+  "path-H961.13": {
+    "H961.13": 1,
+    "path-H961.15": 3,
+    "path-H961.14": 1
+  },
+  "path-H280.2": {
+    "H280": 7,
+    "path-H280": 5
+  },
+  "H865": {
+    "path-H867-H865": 1
+  },
+  "path-H801-H63-5-7": {
+    "path-H863": 2,
+    "path-H867-H865": 5,
+    "path-H801": 2
+  },
+  "path-H807": {
+    "H807": 2,
+    "path-H8wbath": 8,
+    "path-H807-H8mbath": 6
+  },
+  "H967": {
+    "path-H967": 2
+  },
+  "H815": {
+    "path-H815": 2
+  },
+  "path-principalEntrance": {
+    "path-H1.2-Hall-principal-entrance": 23,
+    "path-escalatorH1": 10,
+    "path-H102-3": 16
+  },
+  "path-H928": {
+    "path-H927": 4,
+    "H928": 1,
+    "path-H927.1": 3
+  },
+  "H855": {
+    "path-H855": 2
+  },
+  "path-H925.1": {
+    "H925.1": 2,
+    "path-H925.2": 3
+  },
+  "path-UpH8escalator-junction": {
+    "path-H8stairs4-H8elevator-H861-59-UpH8escalator": 16,
+    "path-UpH8escalator": 4,
+    "path-H807-H8mbath": 15
+  },
+  "path-H925.2": {
+    "path-H925.1": 3,
+    "H925.2": 9,
+    "path-H9wbath": 36,
+    "path-H923": 3
+  },
+  "H906": {
+    "path-H906": 1
+  },
+  "H961.6": {
+    "path-H961.6": 1
+  },
+  "H902": {
+    "path-H902": 1
+  },
+  "H8stairs3": {
+    "path-H8stairs3": 2,
+    "H9stairs2": 5
+  },
+  "path-DownH8escalator": {
+    "path-UpH8escalator": 12,
+    "DownH8escalator": 8,
+    "path-H841-H837": 11
+  },
+  "path-H9stairs4": {
+    "H9stairs4": 1,
+    "path-H9mbath": 3,
+    "path-H990": 2
+  },
+  "path-H961.7": {
+    "H961.7": 1,
+    "path-H961.97": 1,
+    "path-H961.7.2": 1
+  },
+  "H919": {
+    "path-H919": 2
+  },
+  "path-H845": {
+    "path-H843": 6,
+    "H845": 3,
+    "path-H8stairs3": 2
+  },
+  "H801": {
+    "path-H801": 2
+  },
+  "path-H964": {
+    "H964": 2,
+    "path-H964.1": 3,
+    "path-H9stairs3": 1
+  },
+  "escalator-up1H2": {
+    "path-H220": 9,
+    "escalator-upH1": 13
+  },
+  "path-H961.23": {
+    "H961.23": 1,
+    "path-H961.21": 3,
+    "path-H961.25": 3
+  },
+  "H847": {
+    "path-H847": 2
+  },
+  "path-H961.41": {
+    "path-H961.33": 2,
+    "path-H945": 7
+  },
+  "H945": {
+    "path-H945": 2
+  },
+  "path-H961.11": {
+    "H961.11": 16,
+    "path-H961.2": 16,
+    "path-H961.12": 1,
+    "path-H961.14": 2
+  },
+  "H961.11": {
+    "path-H961.11": 16
+  },
+  "path-H960": {
+    "H960": 4,
+    "path-H9wbath": 21,
+    "path-UpH9escalator": 3,
+    "path-H962.1": 3
+  },
+  "path-H801": {
+    "path-H801-H63-5-7": 2,
+    "H801": 2,
+    "path-H803": 5
+  },
+  "path-H943": {
+    "path-H961.33": 1,
+    "H943": 1,
+    "path-H961.31": 2
+  },
+  "path-H9wbath": {
+    "path-H925.2": 36,
+    "path-H960": 21,
+    "H9wbath": 1,
+    "path-H909": 2,
+    "path-H902": 2,
+    "path-H913": 16
+  },
+  "H8stairs4": {
+    "path-H8stairs4-H8elevator": 1,
+    "H9stairs3": 4
+  },
+  "914": {
+    "path-H914": 1
+  },
+  "H933.11": {
+    "path-H933.11": 1,
+    "H933.1": 1
+  },
+  "path-H853": {
+    "path-H849": 5,
+    "H853": 2,
+    "path-H855": 6
+  },
+  "path-H990": {
+    "H990": 1,
+    "path-H9stairs4": 2,
+    "path-H915": 2
+  },
+  "path-H961.12": {
+    "H961.12": 1,
+    "path-H961.11": 1,
+    "path-H961.1": 2
+  },
+  "path-H8wbath": {
+    "path-H807": 8,
+    "path-H803-H8wbath-H805.1-2-3": 1,
+    "H8wbath": 3
+  },
+  "path-UpH8escalator": {
+    "path-UpH8escalator-junction": 4,
+    "path-DownH8escalator": 12,
+    "UpH8escalator": 8
+  },
+  "path-H861": {
+    "path-H861-59": 5,
+    "H861": 2,
+    "path-H863": 7
+  },
+  "H961.30": {
+    "path-H961.30": 1
+  },
+  "H849": {
+    "path-H849": 4
+  },
+  "H961.4": {
+    "path-H961.4": 1
+  },
+  "H961.33": {
+    "path-H961.33": 1
+  },
+  "path-H925.3": {
+    "H925.3": 2,
+    "path-H980": 3,
+    "path-H920": 1
+  },
+  "path-H961.19": {
+    "H961.19": 2,
+    "path-H961.21": 1,
+    "path-H917": 70,
+    "path-H961.17": 1
+  },
+  "path-H961.28": {
+    "path-H961.27": 1,
+    "H961.28": 1,
+    "path-H961.29": 3
+  },
+  "path-H923": {
+    "H923": 2,
+    "path-H925.2": 3,
+    "path-H986": 2
+  },
+  "H927.4": {
+    "path-H927.4": 1,
+    "H927.3": 9
+  },
+  "H910": {
+    "path-H910": 2
+  },
+  "H861": {
+    "path-H861": 2
+  },
+  "path-H986": {
+    "path-H923": 2,
+    "H986": 1,
+    "path-H921": 7
+  },
+  "path-H220": {
+    "escalator-up1H2": 9,
+    "H220": 7,
+    "path-H280": 8,
+    "path-elevatorH2": 5
+  },
+  "H863": {
+    "path-H863": 2
+  },
+  "H961.27": {
+    "path-H961.27": 1
+  },
+  "H933.2": {
+    "H933.1": 3
+  },
+  "H921": {
+    "path-H921": 2
+  },
+  "H9stairs1": {
+    "path-H9stairs1": 2,
+    "H8stairs2": 3
+  },
+  "H917": {
+    "path-H917": 5,
+    "path-H915": 8
+  },
+  "H867": {
+    "path-H867-H865": 1
+  },
+  "DownH9escalator": {
+    "path-DownH9escalator": 2,
+    "DownH8escalator": 5
+  },
+  "path-H8stairs4-H8elevator": {
+    "H8stairs4": 1,
+    "path-H8stairs4-H8elevator-H861-59-UpH8escalator": 3,
+    "H8elevator": 1
+  },
+  "path-H910": {
+    "H910": 2,
+    "path-H913": 1,
+    "path-H911": 6,
+    "path-H9mbath": 4
+  },
+  "path-H961.7.2": {
+    "path-H961.7": 1,
+    "path-H961.9": 2,
+    "path-H961.8": 7
+  },
+  "H819": {
+    "path-H819": 3
+  },
+  "path-H817": {
+    "path-H815": 2,
+    "path-H819": 2,
+    "H817": 5
+  },
+  "H807": {
+    "path-H807": 2
+  },
+  "path-H914": {
+    "914": 1,
+    "path-H992": 4,
+    "path-H914.2": 3
+  },
+  "path-H980": {
+    "path-H925.3": 3,
+    "H980": 2,
+    "path-H927.4": 2
+  },
+  "H961.1": {
+    "path-H961.1": 1
+  },
+  "path-H961.8": {
+    "path-H961.7.2": 7,
+    "H961.8": 1,
+    "path-H968": 3
+  },
+  "path-H915": {
+    "H915": 3,
+    "path-H990": 2,
+    "H917": 8,
+    "path-H917": 5
+  },
+  "H962": {
+    "path-H962": 2
+  },
+  "path-H964.1": {
+    "path-H964": 3,
+    "H964.1": 2,
+    "path-H963": 1
+  },
+  "H961.2": {
+    "path-H961.2": 1
+  },
+  "path-H913": {
+    "path-H910": 1,
+    "H913": 3,
+    "path-H9wbath": 16,
+    "path-H961.15": 57
+  },
+  "path-H968": {
+    "path-H961.8": 3,
+    "H968": 1,
+    "path-H9stairs2": 6
+  },
+  "elevatorH2": {
+    "path-H1stairs2": 18,
+    "elevatorH1": 10,
+    "path-elevatorH2": 7
+  },
+  "path-H8mbath": {
+    "path-H807-H8mbath": 6,
+    "path-H811": 2,
+    "H8mbath": 3
+  },
+  "path-H985": {
+    "H985": 1,
+    "path-H937.1": 8,
+    "path-H937": 4,
+    "path-H937.1.2": 5
+  },
+  "hive-cafe": {
+    "path_hivecafe": 9
+  },
+  "H943": {
+    "path-H943": 1
+  },
+  "H992": {
+    "path-H992": 1
+  },
+  "path-H961.26": {
+    "H961.26": 1,
+    "path-H961.15": 1,
+    "path-H961.17": 2
+  },
+  "path-H961.15": {
+    "path-H961.13": 3,
+    "path-H961.26": 1,
+    "H961.15": 1,
+    "path-H913": 57
+  },
+  "path-H966": {
+    "H966": 1,
+    "path-H975": 1,
+    "path-H9stairs2": 2
+  },
+  "H835": {
+    "path-H835": 3
+  },
+  "path-H998": {
+    "H998": 1,
+    "path-H9stairs3": 1,
+    "path-H962": 4
+  },
+  "H961.97": {
+    "path-H961.97": 1
+  },
+  "path-H280.3": {
+    "path-H280": 7,
+    "stairsH2": 8
+  },
+  "H927": {
+    "path-H927": 1
+  },
+  "path-H807-H8mbath": {
+    "path-H807": 6,
+    "path-UpH8escalator-junction": 15,
+    "path-H8mbath": 6
+  },
+  "H961.7": {
+    "path-H961.7": 1
+  },
+  "path-H961.29": {
+    "path-H961.28": 3,
+    "H961.29": 1,
+    "path-H961.30": 1
+  },
+  "H821": {
+    "path-H821": 3
+  },
+  "path-H927.4.2": {
+    "path-H927": 7,
+    "path-H927.4": 1,
+    "path-H9stairs1": 9
+  },
+  "H8stairs1": {
+    "path-H8stairs1": 2,
+    "H9stairs4": 4
+  },
+  "path-H962": {
+    "H962": 2,
+    "path-H998": 4,
+    "Path-H9elevator": 1
+  },
+  "path-H102-3": {
+    "path-principalEntrance": 16,
+    "stairs1H1": 11,
+    "H102-3": 9
+  },
+  "path-H803-H8wbath-H805.1-2-3": {
+    "path-H8wbath": 1,
+    "path-H803": 4,
+    "path-H805.1-2-3": 3
+  },
+  "H961.12": {
+    "path-H961.12": 1
+  },
+  "stairsH2": {
+    "path-H280.3": 8,
+    "path-H8stairs2": 25,
+    "stairs2H1": 6
+  },
+  "path-H1stairs1": {
+    "path-H1stairs2": 5,
+    "stairs1H1": 4,
+    "H102-3": 2
+  },
+  "H985": {
+    "path-H985": 1
+  },
+  "path-H859": {
+    "H859": 2,
+    "path-H857": 7,
+    "path-H861-59": 3
+  },
+  "H961.": {
+    "path-H961.9": 1
+  },
+  "H933.1": {
+    "H933.11": 1,
+    "H933.2": 3
+  },
+  "path-H961.14": {
+    "path-H961.13": 1,
+    "H961.14": 1,
+    "path-H961.11": 2
+  },
+  "H929.25": {
+    "H941": 10
+  },
+  "path-H921": {
+    "path-H986": 7,
+    "H921": 2,
+    "path-H919": 4
+  },
+  "H8mbath": {
+    "path-H8mbath": 3
+  },
+  "H961.8": {
+    "path-H961.8": 1
+  },
+  "path-H962.1": {
+    "H962.1": 4,
+    "path-H960": 3,
+    "path-H960.2": 3
+  },
+  "H899.51": {
+    "path-H899.51-H831": 3
+  },
+  "H963": {
+    "path-H963": 2
+  },
+  "path-H917": {
+    "path-H961.19": 70,
+    "H917": 5,
+    "path-H915": 5,
+    "path-H919": 1
+  },
+  "H220": {
+    "path-H220": 7
+  },
+  "path-H907": {
+    "H907": 2,
+    "path-H902": 1,
+    "path-H903.2": 8
+  },
+  "path-H803": {
+    "path-H801": 5,
+    "path-H803-H8wbath-H805.1-2-3": 4,
+    "H803": 2
+  },
+  "path-escalatorup1H2": {
+    "path_hivecafe": 13,
+    "path-escalatordownH2": 10,
+    "escalator-up2H2": 7,
+    "path-elevatorH2": 6
+  },
+  "path-H811": {
+    "path-H8mbath": 2,
+    "H811": 2,
+    "path-H8stairs1": 6
+  },
+  "path-H960.2": {
+    "path-H962.1": 3,
+    "H960.2": 3,
+    "path-DownH9escalator": 3
+  },
+  "path-H961.6": {
+    "H961.6": 1,
+    "path-H961.97": 3,
+    "path-H961.3": 1
+  },
+  "H927.3": {
+    "H927.1": 4,
+    "H927.4": 9
+  },
+  "path-H899.51-H831": {
+    "H899.51": 3,
+    "H831": 5,
+    "path-H833": 2,
+    "path-H829": 5
+  },
+  "path-H9mbath": {
+    "path-H9stairs4": 3,
+    "H9mbath": 2,
+    "path-H910": 4,
+    "path-H9mbath": 0
+  },
+  "H961.19": {
+    "path-H961.19": 2
+  },
+  "UpH9escalator": {
+    "path-UpH9escalator": 3,
+    "UpH8escalator": 4
+  },
+  "H9stairs3": {
+    "H8stairs4": 4,
+    "path-H9stairs3": 1
+  },
+  "path-H280": {
+    "path-H280.2": 5,
+    "path-H220": 8,
+    "path-H280.3": 7
+  },
+  "path-H927.1": {
+    "H927.1": 20,
+    "path-H928": 3,
+    "path-H929": 1
+  },
+  "path-H961.31": {
+    "path-H943": 2,
+    "H961.31": 1,
+    "path-H961.3": 28,
+    "path-H961.30": 3
+  },
+  "H831": {
+    "path-H899.51-H831": 5
+  },
+  "stairs2H1": {
+    "path-H1stairs2": 9,
+    "stairsH2": 6
+  },
+  "path-H906": {
+    "H906": 1,
+    "path-H911": 2,
+    "path-H914.2": 11,
+    "path-H909": 8
+  },
+  "H857": {
+    "path-H857": 2
+  },
+  "H966.1": {
+    "path-H966.1": 2
+  },
+  "H937": {
+    "path-H937": 2
+  },
+  "H805.1": {
+    "path-H805.1-2-3": 1
+  },
+  "H805.3": {
+    "path-H805.2-3": 1
+  },
+  "path-H961.17": {
+    "path-H961.26": 2,
+    "H961.17": 1,
+    "path-H961.19": 1
+  },
+  "H965": {
+    "path-H965": 2
+  },
+  "path-H841": {
+    "H841": 3,
+    "path-H841-H837": 7,
+    "path-H843": 5
+  },
+  "H9elevator": {
+    "Path-H9elevator": 1,
+    "H8elevator": 6
+  },
+  "path-H929": {
+    "path-H927.1": 1,
+    "path-H933": 3,
+    "H9291": 2
+  },
+  "H803": {
+    "path-H803": 2
+  },
+  "path-DownH9escalator": {
+    "DownH9escalator": 2,
+    "path-H960.2": 3,
+    "path-H966.1": 4,
+    "path-H937.1": 5
+  },
+  "H9291": {
+    "path-H929": 2
+  },
+  "path-H1-Hall-principal-entrance": {
+    "H110": 8,
+    "Hall-principal-entrance": 11
+  },
+  "H986": {
+    "path-H986": 1
+  },
+  "path-H857": {
+    "path-H859": 7,
+    "H857": 2,
+    "path-H855": 7
+  },
+  "path-H961.3": {
+    "H961.3": 1,
+    "path-H961.6": 1,
+    "path-H961.31": 28,
+    "path-H961.4": 2
+  },
+  "path-H961.2": {
+    "path-H961.11": 16,
+    "H961.2": 1,
+    "path-H961.4": 3
+  },
+  "path-H975": {
+    "path-H966": 1,
+    "H975": 1,
+    "path-H981.2": 7
+  },
+  "path-H825": {
+    "path-H823": 7,
+    "H825": 3,
+    "path-H827": 7
+  },
+  "H961.14": {
+    "path-H961.14": 1
+  },
+  "path-H867-H865": {
+    "H865": 1,
+    "path-H801-H63-5-7": 5,
+    "H867": 1
+  },
+  "H960": {
+    "path-H960": 4
+  },
+  "path-H961.30": {
+    "H961.30": 1,
+    "path-H961.29": 1,
+    "path-H961.31": 3
+  },
+  "UpH8escalator": {
+    "path-UpH8escalator": 8,
+    "UpH9escalator": 4,
+    "escalator-up2H2": 6
+  },
+  "path-H815": {
+    "H815": 2,
+    "path-H817": 2,
+    "path-H813": 6
+  },
+  "path-H966.1": {
+    "path-H937.1": 5,
+    "H966.1": 2,
+    "path-DownH9escalator": 4,
+    "path-H981.2": 3
+  },
+  "H925.2": {
+    "path-H925.2": 9
+  },
+  "path-H805.1-2-3": {
+    "path-H805.2-3": 3,
+    "path-H803-H8wbath-H805.1-2-3": 3,
+    "H805.1": 1
+  },
+  "H923": {
+    "path-H923": 2
+  },
+  "H805.2": {
+    "path-H805.2-3": 1
+  },
+  "path-H961.9": {
+    "path-H961.7.2": 2,
+    "H961.": 1,
+    "path-H961.1": 1,
+    "path-H961.21": 14
+  },
+  "H9wbath": {
+    "path-H9wbath": 1
+  },
+  "H829": {
+    "path-H829": 3
+  },
+  "path-H961.97": {
+    "path-H961.7": 1,
+    "H961.97": 1,
+    "path-H961.6": 3
+  },
+  "H825": {
+    "path-H825": 3
+  },
+  "H941": {
+    "H929.25": 10
+  },
+  "H9stairs4": {
+    "path-H9stairs4": 1,
+    "H8stairs1": 4
+  },
+  "H961.25": {
+    "path-H961.25": 1
+  },
+  "elevatorH1": {
+    "path-H1stairs2": 12,
+    "elevatorH2": 10
+  },
+  "H102-3": {
+    "path-H102-3": 9,
+    "path-H1stairs1": 2
+  },
+  "escalator-up2H2": {
+    "path-escalatorup1H2": 7,
+    "UpH8escalator": 6
+  },
+  "path-H945": {
+    "path-H961.41": 7,
+    "H945": 2,
+    "path-H983": 1
+  },
+  "Path-H9elevator": {
+    "path-H962": 1,
+    "H9elevator": 1,
+    "path-H992": 3
+  },
+  "H853": {
+    "path-H853": 2
+  },
+  "path-escalatordownH2": {
+    "path-escalatorup1H2": 10,
+    "escalator-down2H2": 8,
+    "escalator-downH1": 10
+  },
+  "path-H833": {
+    "path-H899.51-H831": 2,
+    "H833": 3,
+    "path-H835": 7
+  },
+  "path-H9stairs3": {
+    "path-H964": 1,
+    "path-H998": 1,
+    "H9stairs3": 1
+  },
+  "path-H903": {
+    "H903": 5,
+    "path-H903.2": 2
+  },
+  "path-H927.4": {
+    "H927.4": 1,
+    "path-H980": 2,
+    "path-H927.4.2": 1
+  },
+  "path-H861-59": {
+    "path-H861": 5,
+    "path-H859": 3,
+    "path-H8stairs4-H8elevator-H861-59-UpH8escalator": 10
+  },
+  "path-H821": {
+    "H821": 3,
+    "path-H819": 7,
+    "path-H823": 7
+  },
+  "H961.17": {
+    "path-H961.17": 1
+  },
+  "H968": {
+    "path-H968": 1
+  },
+  "H837": {
+    "path-H837": 3
+  },
+  "H964": {
+    "path-H964": 2
+  },
+  "H962.1": {
+    "path-H962.1": 4
+  },
+  "path-H8stairs3": {
+    "H8stairs3": 2,
+    "path-H845": 2,
+    "path-H847": 4
+  },
+  "stairs1H1": {
+    "path-H102-3": 11,
+    "path-H1stairs1": 4
+  },
+  "H964.3": {
+    "H964.2": 2
+  },
+  "path-H813": {
+    "path-H815": 6,
+    "path-H8stairs1": 1,
+    "H813": 2
+  },
+  "path-H911": {
+    "path-H910": 6,
+    "path-H906": 2,
+    "H911": 3,
+    "path-H909": 7
+  },
+  "path-H961.1": {
+    "path-H961.12": 2,
+    "H961.1": 1,
+    "path-H961.9": 1
+  },
+  "path-H937": {
+    "path-H933.11": 7,
+    "path-H985": 4,
+    "H937": 2
+  },
+  "path-H961.4": {
+    "H961.4": 1,
+    "path-H961.3": 2,
+    "path-H961.2": 3
+  },
+  "path-H9stairs1": {
+    "H9stairs1": 2,
+    "path-H927.4.2": 9,
+    "path-H9stairs1": 0,
+    "path-H937.1.2": 3
+  },
+  "H964.1": {
+    "H964.2": 4,
+    "path-H964.1": 2
+  },
+  "H960.2": {
+    "path-H960.2": 3
+  },
+  "H845": {
+    "path-H845": 3
+  },
+  "H8wbath": {
+    "path-H8wbath": 3
+  },
+  "path-H933": {
+    "path-H929": 3,
+    "H933": 2,
+    "path-H932": 3
+  },
+  "H813": {
+    "path-H813": 2
+  },
+  "H961.28": {
+    "path-H961.28": 1
+  },
+  "path-elevatorH2": {
+    "path-H220": 5,
+    "path-escalatorup1H2": 6,
+    "elevatorH2": 7
+  },
+  "DownH8escalator": {
+    "path-DownH8escalator": 8,
+    "DownH9escalator": 5,
+    "escalator-down2H2": 7
+  },
+  "H980": {
+    "path-H980": 2
+  },
+  "escalator-down2H2": {
+    "path-escalatordownH2": 8,
+    "DownH8escalator": 7
+  },
+  "path-H819": {
+    "H819": 3,
+    "path-H817": 2,
+    "path-H821": 7
+  },
+  "H833": {
+    "path-H833": 3
+  },
+  "H811": {
+    "path-H811": 2
+  },
+  "H843": {
+    "path-H843": 3
+  },
+  "path-H8stairs2": {
+    "stairsH2": 25,
+    "path-H835": 1,
+    "H8stairs2": 2,
+    "path-H837": 6
+  },
+  "path-H967": {
+    "H967": 2,
+    "path-H965": 5,
+    "path-H903.2": 1
+  },
+  "path-H902": {
+    "H902": 1,
+    "path-H9wbath": 2,
+    "path-H907": 1
+  },
+  "path-H981.2": {
+    "path-H975": 7,
+    "path-H966.1": 3,
+    "path-H981": 6
+  },
+  "path-H847": {
+    "path-H849": 2,
+    "H847": 2,
+    "path-H8stairs3": 4
+  },
+  "path-H827": {
+    "H827": 3,
+    "path-H825": 7,
+    "path-H829": 7
+  },
+  "path-H841-H837": {
+    "path-DownH8escalator": 11,
+    "path-H841": 7,
+    "path-H837": 7
+  },
+  "path-H909": {
+    "path-H9wbath": 2,
+    "path-H911": 7,
+    "H909": 2,
+    "path-H906": 8
+  },
+  "H9stairs2": {
+    "H8stairs3": 5,
+    "path-H9stairs2": 1
+  },
+  "H933": {
+    "path-H933": 2
+  },
+  "H907": {
+    "path-H907": 2
+  },
+  "path-H992": {
+    "path-H914": 4,
+    "H992": 1,
+    "Path-H9elevator": 3
+  },
+  "H920": {
+    "path-H920": 2
+  },
+  "H975": {
+    "path-H975": 1
+  },
+  "path-H9stairs2": {
+    "path-H968": 6,
+    "path-H966": 2,
+    "H9stairs2": 1
+  },
+  "H961.26": {
+    "path-H961.26": 1
+  },
+  "path-H981": {
+    "path-H981.2": 6,
+    "H981": 2,
+    "path-H981": 0,
+    "path-H983": 2
+  },
+  "path-H829": {
+    "H829": 3,
+    "path-H827": 7,
+    "path-H899.51-H831": 5
+  },
+  "H925.1": {
+    "path-H925.1": 2
+  },
+  "H961.15": {
+    "path-H961.15": 1
+  },
+  "path-H823": {
+    "path-H825": 7,
+    "path-H821": 7,
+    "H823": 3
+  },
+  "H913": {
+    "path-H913": 3
+  },
+  "path-H837": {
+    "H837": 3,
+    "path-H8stairs2": 6,
+    "path-H841-H837": 7
+  },
+  "escalator-upH1": {
+    "escalator-up1H2": 13,
+    "path-escalatorH1": 2
+  },
+  "H983": {
+    "path-H983": 1
+  },
+  "path-H8stairs4-H8elevator-H861-59-UpH8escalator": {
+    "path-UpH8escalator-junction": 16,
+    "path-H8stairs4-H8elevator": 3,
+    "path-H861-59": 10
+  },
+  "H928": {
+    "path-H928": 1
+  },
+  "path-H863": {
+    "path-H801-H63-5-7": 2,
+    "path-H861": 7,
+    "H863": 2
+  },
+  "H817": {
+    "path-H817": 5
+  },
+  "H961.13": {
+    "path-H961.13": 1
+  },
+  "path-H903.2": {
+    "path-H907": 8,
+    "path-H903": 2,
+    "path-H967": 1
+  },
+  "H981": {
+    "path-H981": 2
+  },
+  "path-H932": {
+    "path-H933.11": 2,
+    "path-H933": 3,
+    "H932": 1
+  },
+  "H961.21": {
+    "path-H961.21": 1
+  },
+  "H110": {
+    "path-H1-Hall-principal-entrance": 8,
+    "Hall-principal-entrance": 14
+  },
+  "H961.29": {
+    "path-H961.29": 1
+  },
+  "path-H8stairs1": {
+    "H8stairs1": 2,
+    "path-H811": 6,
+    "path-H813": 1
+  },
+  "path-H835": {
+    "H835": 3,
+    "path-H833": 7,
+    "path-H8stairs2": 1
+  },
+  "path-H961.21": {
+    "path-H961.23": 3,
+    "path-H961.19": 1,
+    "H961.21": 1,
+    "path-H961.9": 14
+  },
+  "H823": {
+    "path-H823": 3
+  },
+  "escalator-downH1": {
+    "path-escalatordownH2": 10,
+    "path-escalatorH1": 2
+  },
+  "path-H963": {
+    "path-H964.1": 1,
+    "H963": 2,
+    "path-H965": 6
+  },
+  "H961.31": {
+    "path-H961.31": 1
+  },
+  "H998": {
+    "path-H998": 1
+  },
+  "H911": {
+    "path-H911": 3
+  },
+  "H903": {
+    "path-H903": 5
+  },
+  "path-H965": {
+    "path-H967": 5,
+    "path-H963": 6,
+    "H965": 2
+  },
+  "H937.1": {
+    "path-H937.1": 5
+  },
+  "H961.23": {
+    "path-H961.23": 1
+  },
+  "path-H961.25": {
+    "path-H961.27": 4,
+    "path-H961.23": 3,
+    "H961.25": 1
+  },
+  "path-H920": {
+    "path-H925.3": 1,
+    "H920": 2
+  },
+  "H925.3": {
+    "path-H925.3": 2
+  },
+  "path-UpH9escalator": {
+    "path-H960": 3,
+    "UpH9escalator": 3,
+    "path-H914.2": 3
+  },
+  "H9mbath": {
+    "path-H9mbath": 2
+  },
+  "Hall-principal-entrance": {
+    "path-H1.2-Hall-principal-entrance": 8,
+    "path-H1-Hall-principal-entrance": 11,
+    "H110": 14
+  },
+  "H932": {
+    "path-H932": 1
+  },
+  "path-escalatorH1": {
+    "path-principalEntrance": 10,
+    "escalator-upH1": 2,
+    "escalator-downH1": 2
+  },
+  "H8stairs2": {
+    "H9stairs1": 3,
+    "path-H8stairs2": 2
+  },
+  "path-H937.1.2": {
+    "path-H937.1": 6,
+    "path-H9stairs1": 3,
+    "path-H985": 5
+  },
+  "path-H914.2": {
+    "path-H914": 3,
+    "path-H906": 11,
+    "path-UpH9escalator": 3
+  },
+  "path-H919": {
+    "H919": 2,
+    "path-H921": 4,
+    "path-H917": 1
+  },
+  "path-H843": {
+    "path-H845": 6,
+    "path-H841": 5,
+    "H843": 3
+  },
+  "path-H855": {
+    "H855": 2,
+    "path-H853": 6,
+    "path-H857": 7
+  },
+  "path-H983": {
+    "path-H945": 1,
+    "H983": 1,
+    "path-H981": 2
+  },
+  "H8elevator": {
+    "path-H8stairs4-H8elevator": 1,
+    "H9elevator": 6
+  },
+  "H909": {
+    "path-H909": 2
+  }
+}
+
+export const hNodeCoordinates = {
+  "path-H961.33": {
+    "coordinates": [
+      -73.578683,
+      45.497062
+    ],
+    "floor": 9
+  },
+  "path-H937.1": {
+    "coordinates": [
+      -73.578758,
+      45.497241
+    ],
+    "floor": 9
+  },
+  "path-H805.2-3": {
+    "coordinates": [
+      -73.579316,
+      45.497325
+    ],
+    "floor": 8
+  },
+  "H827": {
+    "coordinates": [
+      -73.578643,
+      45.497455
+    ],
+    "floor": 8
+  },
+  "H927.1": {
+    "coordinates": [
+      -73.578542,
+      45.497475
+    ],
+    "floor": 9
+  },
+  "H966": {
+    "coordinates": [
+      -73.578886,
+      45.497127
+    ],
+    "floor": 9
+  },
+  "path_hivecafe": {
+    "coordinates": [
+      -73.579056,
+      45.49742
+    ],
+    "floor": 0
+  },
+  "H280": {
+    "coordinates": [
+      -73.578817,
+      45.497563
+    ],
+    "floor": 2
+  },
+  "path-H849": {
+    "coordinates": [
+      -73.578876,
+      45.496996
+    ],
+    "floor": 8
+  },
+  "H841": {
+    "coordinates": [
+      -73.578712,
+      45.497127
+    ],
+    "floor": 8
+  },
+  "path-H933.11": {
+    "coordinates": [
+      -73.578534,
+      45.497238
+    ],
+    "floor": 9
+  },
+  "path-H961.27": {
+    "coordinates": [
+      -73.578765,
+      45.496981
+    ],
+    "floor": 9
+  },
+  "path-H1stairs2": {
+    "coordinates": [
+      -73.578596,
+      45.497417
+    ],
+    "floor": 1
+  },
+  "path-H1.2-Hall-principal-entrance": {
+    "coordinates": [
+      -73.578746,
+      45.497037
+    ],
+    "floor": 1
+  },
+  "H961.3": {
+    "coordinates": [
+      -73.579072,
+      45.49701
+    ],
+    "floor": 9
+  },
+  "path-H927": {
+    "coordinates": [
+      -73.578546,
+      45.497338
+    ],
+    "floor": 9
+  },
+  "H964.2": {
+    "coordinates": [
+      -73.579064,
+      45.497128
+    ],
+    "floor": 9
+  },
+  "H915": {
+    "coordinates": [
+      -73.579017,
+      45.497514
+    ],
+    "floor": 9
+  },
+  "H990": {
+    "coordinates": [
+      -73.57898,
+      45.497479
+    ],
+    "floor": 9
+  },
+  "H859": {
+    "coordinates": [
+      -73.579157,
+      45.497105
+    ],
+    "floor": 8
+  },
+  "path-H961.13": {
+    "coordinates": [
+      -73.578917,
+      45.496944
+    ],
+    "floor": 9
+  },
+  "path-H280.2": {
+    "coordinates": [
+      -73.578746,
+      45.497527
+    ],
+    "floor": 2
+  },
+  "H865": {
+    "coordinates": [
+      -73.579393,
+      45.497197
+    ],
+    "floor": 8
+  },
+  "path-H801-H63-5-7": {
+    "coordinates": [
+      -73.579328,
+      45.497212
+    ],
+    "floor": 8
+  },
+  "path-H807": {
+    "coordinates": [
+      -73.579187,
+      45.497359
+    ],
+    "floor": 8
+  },
+  "H967": {
+    "coordinates": [
+      -73.579258,
+      45.497203
+    ],
+    "floor": 9
+  },
+  "H815": {
+    "coordinates": [
+      -73.579012,
+      45.497577
+    ],
+    "floor": 8
+  },
+  "path-principalEntrance": {
+    "coordinates": [
+      -73.578577,
+      45.497209
+    ],
+    "floor": 0
+  },
+  "path-H928": {
+    "coordinates": [
+      -73.578508,
+      45.497319
+    ],
+    "floor": 9
+  },
+  "H855": {
+    "coordinates": [
+      -73.579008,
+      45.497036
+    ],
+    "floor": 8
+  },
+  "path-H925.1": {
+    "coordinates": [
+      -73.578721,
+      45.497424
+    ],
+    "floor": 9
+  },
+  "path-UpH8escalator-junction": {
+    "coordinates": [
+      -73.578983,
+      45.497329
+    ],
+    "floor": 8
+  },
+  "path-H925.2": {
+    "coordinates": [
+      -73.578751,
+      45.497439
+    ],
+    "floor": 9
+  },
+  "H906": {
+    "coordinates": [
+      -73.57909,
+      45.49736
+    ],
+    "floor": 9
+  },
+  "H961.6": {
+    "coordinates": [
+      -73.579053,
+      45.49702
+    ],
+    "floor": 9
+  },
+  "H902": {
+    "coordinates": [
+      -73.579171,
+      45.497287
+    ],
+    "floor": 9
+  },
+  "H8stairs3": {
+    "coordinates": [
+      -73.578849,
+      45.497055
+    ],
+    "floor": 8
+  },
+  "path-DownH8escalator": {
+    "coordinates": [
+      -73.578813,
+      45.497247
+    ],
+    "floor": 8
+  },
+  "path-H9stairs4": {
+    "coordinates": [
+      -73.579013,
+      45.497468
+    ],
+    "floor": 9
+  },
+  "path-H961.7": {
+    "coordinates": [
+      -73.579019,
+      45.496994
+    ],
+    "floor": 9
+  },
+  "H919": {
+    "coordinates": [
+      -73.578917,
+      45.497543
+    ],
+    "floor": 9
+  },
+  "path-H845": {
+    "coordinates": [
+      -73.578815,
+      45.497063
+    ],
+    "floor": 8
+  },
+  "H801": {
+    "coordinates": [
+      -73.579339,
+      45.497233
+    ],
+    "floor": 8
+  },
+  "path-H964": {
+    "coordinates": [
+      -73.579087,
+      45.497189
+    ],
+    "floor": 9
+  },
+  "escalator-up1H2": {
+    "coordinates": [
+      -73.578739,
+      45.497389
+    ],
+    "floor": 1
+  },
+  "path-H961.23": {
+    "coordinates": [
+      -73.578816,
+      45.49693
+    ],
+    "floor": 9
+  },
+  "H847": {
+    "coordinates": [
+      -73.578837,
+      45.497001
+    ],
+    "floor": 8
+  },
+  "path-H961.41": {
+    "coordinates": [
+      -73.578677,
+      45.497083
+    ],
+    "floor": 9
+  },
+  "H945": {
+    "coordinates": [
+      -73.57873,
+      45.497127
+    ],
+    "floor": 9
+  },
+  "path-H961.11": {
+    "coordinates": [
+      -73.578953,
+      45.496962
+    ],
+    "floor": 9
+  },
+  "H961.11": {
+    "coordinates": [
+      -73.579127,
+      45.497036
+    ],
+    "floor": 9
+  },
+  "path-H960": {
+    "coordinates": [
+      -73.578907,
+      45.497283
+    ],
+    "floor": 9
+  },
+  "path-H801": {
+    "coordinates": [
+      -73.579316,
+      45.497225
+    ],
+    "floor": 8
+  },
+  "path-H943": {
+    "coordinates": [
+      -73.578694,
+      45.497051
+    ],
+    "floor": 9
+  },
+  "path-H9wbath": {
+    "coordinates": [
+      -73.579175,
+      45.497307
+    ],
+    "floor": 9
+  },
+  "H8stairs4": {
+    "coordinates": [
+      -73.579135,
+      45.497214
+    ],
+    "floor": 8
+  },
+  "914": {
+    "coordinates": [
+      -73.579001,
+      45.497296
+    ],
+    "floor": 9
+  },
+  "H933.11": {
+    "coordinates": [
+      -73.578521,
+      45.497232
+    ],
+    "floor": 9
+  },
+  "path-H853": {
+    "coordinates": [
+      -73.578924,
+      45.497019
+    ],
+    "floor": 8
+  },
+  "path-H990": {
+    "coordinates": [
+      -73.578995,
+      45.497486
+    ],
+    "floor": 9
+  },
+  "path-H961.12": {
+    "coordinates": [
+      -73.57896,
+      45.496965
+    ],
+    "floor": 9
+  },
+  "path-H8wbath": {
+    "coordinates": [
+      -73.579245,
+      45.4973
+    ],
+    "floor": 8
+  },
+  "path-UpH8escalator": {
+    "coordinates": [
+      -73.578941,
+      45.497309
+    ],
+    "floor": 8
+  },
+  "path-H861": {
+    "coordinates": [
+      -73.579225,
+      45.497161
+    ],
+    "floor": 8
+  },
+  "H961.30": {
+    "coordinates": [
+      -73.578744,
+      45.497024
+    ],
+    "floor": 9
+  },
+  "H849": {
+    "coordinates": [
+      -73.578868,
+      45.496965
+    ],
+    "floor": 8
+  },
+  "H961.4": {
+    "coordinates": [
+      -73.579084,
+      45.497034
+    ],
+    "floor": 9
+  },
+  "H961.33": {
+    "coordinates": [
+      -73.57867,
+      45.497056
+    ],
+    "floor": 9
+  },
+  "path-H925.3": {
+    "coordinates": [
+      -73.578689,
+      45.497408
+    ],
+    "floor": 9
+  },
+  "path-H961.19": {
+    "coordinates": [
+      -73.578841,
+      45.496906
+    ],
+    "floor": 9
+  },
+  "path-H961.28": {
+    "coordinates": [
+      -73.578754,
+      45.496991
+    ],
+    "floor": 9
+  },
+  "path-H923": {
+    "coordinates": [
+      -73.578785,
+      45.497455
+    ],
+    "floor": 9
+  },
+  "H927.4": {
+    "coordinates": [
+      -73.578624,
+      45.497389
+    ],
+    "floor": 9
+  },
+  "H910": {
+    "coordinates": [
+      -73.579045,
+      45.497413
+    ],
+    "floor": 9
+  },
+  "H861": {
+    "coordinates": [
+      -73.579238,
+      45.497145
+    ],
+    "floor": 8
+  },
+  "path-H986": {
+    "coordinates": [
+      -73.578811,
+      45.497468
+    ],
+    "floor": 9
+  },
+  "path-H220": {
+    "coordinates": [
+      -73.578837,
+      45.497436
+    ],
+    "floor": 2
+  },
+  "H863": {
+    "coordinates": [
+      -73.579319,
+      45.497181
+    ],
+    "floor": 8
+  },
+  "H961.27": {
+    "coordinates": [
+      -73.57875,
+      45.496975
+    ],
+    "floor": 9
+  },
+  "H933.2": {
+    "coordinates": [
+      -73.578506,
+      45.4972
+    ],
+    "floor": 9
+  },
+  "H921": {
+    "coordinates": [
+      -73.578872,
+      45.497521
+    ],
+    "floor": 9
+  },
+  "H9stairs1": {
+    "coordinates": [
+      -73.578663,
+      45.497294
+    ],
+    "floor": 9
+  },
+  "H917": {
+    "coordinates": [
+      -73.578975,
+      45.497571
+    ],
+    "floor": 9
+  },
+  "H867": {
+    "coordinates": [
+      -73.579399,
+      45.49721
+    ],
+    "floor": 8
+  },
+  "DownH9escalator": {
+    "coordinates": [
+      -73.578831,
+      45.497223
+    ],
+    "floor": 9
+  },
+  "path-H8stairs4-H8elevator": {
+    "coordinates": [
+      -73.579128,
+      45.497221
+    ],
+    "floor": 8
+  },
+  "path-H910": {
+    "coordinates": [
+      -73.579062,
+      45.49742
+    ],
+    "floor": 9
+  },
+  "path-H961.7.2": {
+    "coordinates": [
+      -73.579006,
+      45.496988
+    ],
+    "floor": 9
+  },
+  "H819": {
+    "coordinates": [
+      -73.578934,
+      45.497591
+    ],
+    "floor": 8
+  },
+  "path-H817": {
+    "coordinates": [
+      -73.578975,
+      45.497578
+    ],
+    "floor": 8
+  },
+  "H807": {
+    "coordinates": [
+      -73.57921,
+      45.497369
+    ],
+    "floor": 8
+  },
+  "path-H914": {
+    "coordinates": [
+      -73.578988,
+      45.497291
+    ],
+    "floor": 9
+  },
+  "path-H980": {
+    "coordinates": [
+      -73.578657,
+      45.497392
+    ],
+    "floor": 9
+  },
+  "H961.1": {
+    "coordinates": [
+      -73.578973,
+      45.496981
+    ],
+    "floor": 9
+  },
+  "path-H961.8": {
+    "coordinates": [
+      -73.578959,
+      45.497038
+    ],
+    "floor": 9
+  },
+  "path-H915": {
+    "coordinates": [
+      -73.578983,
+      45.497498
+    ],
+    "floor": 9
+  },
+  "H962": {
+    "coordinates": [
+      -73.579031,
+      45.497221
+    ],
+    "floor": 9
+  },
+  "path-H964.1": {
+    "coordinates": [
+      -73.579108,
+      45.497168
+    ],
+    "floor": 9
+  },
+  "H961.2": {
+    "coordinates": [
+      -73.579111,
+      45.497047
+    ],
+    "floor": 9
+  },
+  "path-H913": {
+    "coordinates": [
+      -73.579053,
+      45.497428
+    ],
+    "floor": 9
+  },
+  "path-H968": {
+    "coordinates": [
+      -73.578937,
+      45.497059
+    ],
+    "floor": 9
+  },
+  "elevatorH2": {
+    "coordinates": [
+      -73.578811,
+      45.497361
+    ],
+    "floor": 2
+  },
+  "path-H8mbath": {
+    "coordinates": [
+      -73.579097,
+      45.497452
+    ],
+    "floor": 8
+  },
+  "path-H985": {
+    "coordinates": [
+      -73.578656,
+      45.497259
+    ],
+    "floor": 9
+  },
+  "hive-cafe": {
+    "coordinates": [
+      -73.579126,
+      45.497351
+    ],
+    "floor": 0
+  },
+  "H943": {
+    "coordinates": [
+      -73.578708,
+      45.497058
+    ],
+    "floor": 9
+  },
+  "H992": {
+    "coordinates": [
+      -73.579029,
+      45.497267
+    ],
+    "floor": 9
+  },
+  "path-H961.26": {
+    "coordinates": [
+      -73.578876,
+      45.496923
+    ],
+    "floor": 9
+  },
+  "path-H961.15": {
+    "coordinates": [
+      -73.578886,
+      45.496928
+    ],
+    "floor": 9
+  },
+  "path-H966": {
+    "coordinates": [
+      -73.578874,
+      45.497121
+    ],
+    "floor": 9
+  },
+  "H835": {
+    "coordinates": [
+      -73.578557,
+      45.497287
+    ],
+    "floor": 8
+  },
+  "path-H998": {
+    "coordinates": [
+      -73.579075,
+      45.497202
+    ],
+    "floor": 9
+  },
+  "H961.97": {
+    "coordinates": [
+      -73.579024,
+      45.497006
+    ],
+    "floor": 9
+  },
+  "path-H280.3": {
+    "coordinates": [
+      -73.578708,
+      45.497459
+    ],
+    "floor": 2
+  },
+  "H927": {
+    "coordinates": [
+      -73.578538,
+      45.497347
+    ],
+    "floor": 9
+  },
+  "path-H807-H8mbath": {
+    "coordinates": [
+      -73.579142,
+      45.497404
+    ],
+    "floor": 8
+  },
+  "H961.7": {
+    "coordinates": [
+      -73.579025,
+      45.496987
+    ],
+    "floor": 9
+  },
+  "path-H961.29": {
+    "coordinates": [
+      -73.578735,
+      45.49701
+    ],
+    "floor": 9
+  },
+  "H821": {
+    "coordinates": [
+      -73.578861,
+      45.497558
+    ],
+    "floor": 8
+  },
+  "path-H927.4.2": {
+    "coordinates": [
+      -73.578621,
+      45.497374
+    ],
+    "floor": 9
+  },
+  "H8stairs1": {
+    "coordinates": [
+      -73.579014,
+      45.497498
+    ],
+    "floor": 8
+  },
+  "path-H962": {
+    "coordinates": [
+      -73.579049,
+      45.497229
+    ],
+    "floor": 9
+  },
+  "path-H102-3": {
+    "coordinates": [
+      -73.578459,
+      45.497329
+    ],
+    "floor": 1
+  },
+  "path-H803-H8wbath-H805.1-2-3": {
+    "coordinates": [
+      -73.57925,
+      45.497294
+    ],
+    "floor": 8
+  },
+  "H961.12": {
+    "coordinates": [
+      -73.578955,
+      45.496972
+    ],
+    "floor": 9
+  },
+  "stairsH2": {
+    "coordinates": [
+      -73.578654,
+      45.497518
+    ],
+    "floor": 2
+  },
+  "path-H1stairs1": {
+    "coordinates": [
+      -73.57854,
+      45.49739
+    ],
+    "floor": 1
+  },
+  "H985": {
+    "coordinates": [
+      -73.578651,
+      45.497264
+    ],
+    "floor": 9
+  },
+  "path-H859": {
+    "coordinates": [
+      -73.579141,
+      45.497122
+    ],
+    "floor": 8
+  },
+  "H961.": {
+    "coordinates": [
+      -73.578991,
+      45.496972
+    ],
+    "floor": 9
+  },
+  "H933.1": {
+    "coordinates": [
+      -73.578508,
+      45.497224
+    ],
+    "floor": 9
+  },
+  "path-H961.14": {
+    "coordinates": [
+      -73.578927,
+      45.496949
+    ],
+    "floor": 9
+  },
+  "H929.25": {
+    "coordinates": [
+      -73.57858,
+      45.49715
+    ],
+    "floor": 9
+  },
+  "path-H921": {
+    "coordinates": [
+      -73.578888,
+      45.497505
+    ],
+    "floor": 9
+  },
+  "H8mbath": {
+    "coordinates": [
+      -73.579066,
+      45.497437
+    ],
+    "floor": 8
+  },
+  "H961.8": {
+    "coordinates": [
+      -73.578948,
+      45.497032
+    ],
+    "floor": 9
+  },
+  "path-H962.1": {
+    "coordinates": [
+      -73.578877,
+      45.497269
+    ],
+    "floor": 9
+  },
+  "H899.51": {
+    "coordinates": [
+      -73.578508,
+      45.497391
+    ],
+    "floor": 8
+  },
+  "H963": {
+    "coordinates": [
+      -73.57913,
+      45.497148
+    ],
+    "floor": 9
+  },
+  "path-H917": {
+    "coordinates": [
+      -73.578946,
+      45.497534
+    ],
+    "floor": 9
+  },
+  "H220": {
+    "coordinates": [
+      -73.578909,
+      45.497471
+    ],
+    "floor": 2
+  },
+  "path-H907": {
+    "coordinates": [
+      -73.579194,
+      45.497286
+    ],
+    "floor": 9
+  },
+  "path-H803": {
+    "coordinates": [
+      -73.579278,
+      45.497264
+    ],
+    "floor": 8
+  },
+  "path-escalatorup1H2": {
+    "coordinates": [
+      -73.578919,
+      45.497355
+    ],
+    "floor": 1
+  },
+  "path-H811": {
+    "coordinates": [
+      -73.579084,
+      45.497466
+    ],
+    "floor": 8
+  },
+  "path-H960.2": {
+    "coordinates": [
+      -73.578846,
+      45.497254
+    ],
+    "floor": 9
+  },
+  "path-H961.6": {
+    "coordinates": [
+      -73.57906,
+      45.497013
+    ],
+    "floor": 9
+  },
+  "H927.3": {
+    "coordinates": [
+      -73.578595,
+      45.497468
+    ],
+    "floor": 9
+  },
+  "path-H899.51-H831": {
+    "coordinates": [
+      -73.578527,
+      45.49737
+    ],
+    "floor": 8
+  },
+  "path-H9mbath": {
+    "coordinates": [
+      -73.579035,
+      45.497446
+    ],
+    "floor": 9
+  },
+  "H961.19": {
+    "coordinates": [
+      -73.57884,
+      45.496892
+    ],
+    "floor": 9
+  },
+  "UpH9escalator": {
+    "coordinates": [
+      -73.578957,
+      45.497275
+    ],
+    "floor": 9
+  },
+  "H9stairs3": {
+    "coordinates": [
+      -73.579092,
+      45.497201
+    ],
+    "floor": 9
+  },
+  "path-H280": {
+    "coordinates": [
+      -73.57878,
+      45.497492
+    ],
+    "floor": 2
+  },
+  "path-H927.1": {
+    "coordinates": [
+      -73.578478,
+      45.497304
+    ],
+    "floor": 9
+  },
+  "path-H961.31": {
+    "coordinates": [
+      -73.578708,
+      45.497037
+    ],
+    "floor": 9
+  },
+  "H831": {
+    "coordinates": [
+      -73.578469,
+      45.497379
+    ],
+    "floor": 8
+  },
+  "stairs2H1": {
+    "coordinates": [
+      -73.578581,
+      45.497495
+    ],
+    "floor": 2
+  },
+  "path-H906": {
+    "coordinates": [
+      -73.579081,
+      45.497369
+    ],
+    "floor": 9
+  },
+  "H857": {
+    "coordinates": [
+      -73.579084,
+      45.49707
+    ],
+    "floor": 8
+  },
+  "H966.1": {
+    "coordinates": [
+      -73.578818,
+      45.497204
+    ],
+    "floor": 9
+  },
+  "H937": {
+    "coordinates": [
+      -73.578632,
+      45.497227
+    ],
+    "floor": 9
+  },
+  "H805.1": {
+    "coordinates": [
+      -73.579276,
+      45.497321
+    ],
+    "floor": 8
+  },
+  "H805.3": {
+    "coordinates": [
+      -73.579327,
+      45.497331
+    ],
+    "floor": 8
+  },
+  "path-H961.17": {
+    "coordinates": [
+      -73.578854,
+      45.496913
+    ],
+    "floor": 9
+  },
+  "H965": {
+    "coordinates": [
+      -73.579202,
+      45.497176
+    ],
+    "floor": 9
+  },
+  "path-H841": {
+    "coordinates": [
+      -73.578741,
+      45.497141
+    ],
+    "floor": 8
+  },
+  "H9elevator": {
+    "coordinates": [
+      -73.579053,
+      45.497247
+    ],
+    "floor": 9
+  },
+  "path-H929": {
+    "coordinates": [
+      -73.578477,
+      45.497298
+    ],
+    "floor": 9
+  },
+  "H803": {
+    "coordinates": [
+      -73.5793,
+      45.497273
+    ],
+    "floor": 8
+  },
+  "path-DownH9escalator": {
+    "coordinates": [
+      -73.578816,
+      45.497239
+    ],
+    "floor": 9
+  },
+  "H9291": {
+    "coordinates": [
+      -73.578453,
+      45.497298
+    ],
+    "floor": 9
+  },
+  "path-H1-Hall-principal-entrance": {
+    "coordinates": [
+      -73.578736,
+      45.496913
+    ],
+    "floor": 1
+  },
+  "H986": {
+    "coordinates": [
+      -73.578819,
+      45.497462
+    ],
+    "floor": 9
+  },
+  "path-H857": {
+    "coordinates": [
+      -73.579067,
+      45.497087
+    ],
+    "floor": 8
+  },
+  "path-H961.3": {
+    "coordinates": [
+      -73.579065,
+      45.497016
+    ],
+    "floor": 9
+  },
+  "path-H961.2": {
+    "coordinates": [
+      -73.579117,
+      45.497041
+    ],
+    "floor": 9
+  },
+  "path-H975": {
+    "coordinates": [
+      -73.578868,
+      45.497129
+    ],
+    "floor": 9
+  },
+  "path-H825": {
+    "coordinates": [
+      -73.578731,
+      45.497465
+    ],
+    "floor": 8
+  },
+  "H961.14": {
+    "coordinates": [
+      -73.578921,
+      45.496955
+    ],
+    "floor": 9
+  },
+  "path-H867-H865": {
+    "coordinates": [
+      -73.579385,
+      45.497204
+    ],
+    "floor": 8
+  },
+  "H960": {
+    "coordinates": [
+      -73.578937,
+      45.497253
+    ],
+    "floor": 9
+  },
+  "path-H961.30": {
+    "coordinates": [
+      -73.578728,
+      45.497017
+    ],
+    "floor": 9
+  },
+  "UpH8escalator": {
+    "coordinates": [
+      -73.579001,
+      45.497249
+    ],
+    "floor": 8
+  },
+  "path-H815": {
+    "coordinates": [
+      -73.578987,
+      45.497566
+    ],
+    "floor": 8
+  },
+  "path-H966.1": {
+    "coordinates": [
+      -73.578793,
+      45.497206
+    ],
+    "floor": 9
+  },
+  "H925.2": {
+    "coordinates": [
+      -73.578688,
+      45.497505
+    ],
+    "floor": 9
+  },
+  "path-H805.1-2-3": {
+    "coordinates": [
+      -73.579284,
+      45.49731
+    ],
+    "floor": 8
+  },
+  "H923": {
+    "coordinates": [
+      -73.57877,
+      45.49747
+    ],
+    "floor": 9
+  },
+  "H805.2": {
+    "coordinates": [
+      -73.579306,
+      45.497334
+    ],
+    "floor": 8
+  },
+  "path-H961.9": {
+    "coordinates": [
+      -73.578985,
+      45.496978
+    ],
+    "floor": 9
+  },
+  "H9wbath": {
+    "coordinates": [
+      -73.579159,
+      45.4973
+    ],
+    "floor": 9
+  },
+  "H829": {
+    "coordinates": [
+      -73.578569,
+      45.497418
+    ],
+    "floor": 8
+  },
+  "path-H961.97": {
+    "coordinates": [
+      -73.57903,
+      45.496999
+    ],
+    "floor": 9
+  },
+  "H825": {
+    "coordinates": [
+      -73.578715,
+      45.497489
+    ],
+    "floor": 8
+  },
+  "H941": {
+    "coordinates": [
+      -73.578663,
+      45.497085
+    ],
+    "floor": 9
+  },
+  "H9stairs4": {
+    "coordinates": [
+      -73.578997,
+      45.497461
+    ],
+    "floor": 9
+  },
+  "H961.25": {
+    "coordinates": [
+      -73.578777,
+      45.496949
+    ],
+    "floor": 9
+  },
+  "elevatorH1": {
+    "coordinates": [
+      -73.578692,
+      45.497328
+    ],
+    "floor": 1
+  },
+  "H102-3": {
+    "coordinates": [
+      -73.578555,
+      45.497375
+    ],
+    "floor": 1
+  },
+  "escalator-up2H2": {
+    "coordinates": [
+      -73.578976,
+      45.497302
+    ],
+    "floor": 2
+  },
+  "path-H945": {
+    "coordinates": [
+      -73.578719,
+      45.497139
+    ],
+    "floor": 9
+  },
+  "Path-H9elevator": {
+    "coordinates": [
+      -73.579038,
+      45.497239
+    ],
+    "floor": 9
+  },
+  "H853": {
+    "coordinates": [
+      -73.57894,
+      45.497004
+    ],
+    "floor": 8
+  },
+  "path-escalatordownH2": {
+    "coordinates": [
+      -73.578817,
+      45.497308
+    ],
+    "floor": 2
+  },
+  "path-H833": {
+    "coordinates": [
+      -73.578538,
+      45.497358
+    ],
+    "floor": 8
+  },
+  "path-H9stairs3": {
+    "coordinates": [
+      -73.57908,
+      45.497196
+    ],
+    "floor": 9
+  },
+  "path-H903": {
+    "coordinates": [
+      -73.579266,
+      45.497216
+    ],
+    "floor": 9
+  },
+  "path-H927.4": {
+    "coordinates": [
+      -73.578633,
+      45.49738
+    ],
+    "floor": 9
+  },
+  "path-H861-59": {
+    "coordinates": [
+      -73.579168,
+      45.497135
+    ],
+    "floor": 8
+  },
+  "path-H821": {
+    "coordinates": [
+      -73.578879,
+      45.497535
+    ],
+    "floor": 8
+  },
+  "H961.17": {
+    "coordinates": [
+      -73.578865,
+      45.496902
+    ],
+    "floor": 9
+  },
+  "H968": {
+    "coordinates": [
+      -73.578949,
+      45.497065
+    ],
+    "floor": 9
+  },
+  "H837": {
+    "coordinates": [
+      -73.57861,
+      45.49723
+    ],
+    "floor": 8
+  },
+  "H964": {
+    "coordinates": [
+      -73.57907,
+      45.497182
+    ],
+    "floor": 9
+  },
+  "H962.1": {
+    "coordinates": [
+      -73.578906,
+      45.497238
+    ],
+    "floor": 9
+  },
+  "path-H8stairs3": {
+    "coordinates": [
+      -73.578831,
+      45.497047
+    ],
+    "floor": 8
+  },
+  "stairs1H1": {
+    "coordinates": [
+      -73.57851,
+      45.497423
+    ],
+    "floor": 1
+  },
+  "H964.3": {
+    "coordinates": [
+      -73.579035,
+      45.497127
+    ],
+    "floor": 9
+  },
+  "path-H813": {
+    "coordinates": [
+      -73.57903,
+      45.49752
+    ],
+    "floor": 8
+  },
+  "path-H911": {
+    "coordinates": [
+      -73.579103,
+      45.497379
+    ],
+    "floor": 9
+  },
+  "path-H961.1": {
+    "coordinates": [
+      -73.578979,
+      45.496974
+    ],
+    "floor": 9
+  },
+  "path-H937": {
+    "coordinates": [
+      -73.578619,
+      45.497241
+    ],
+    "floor": 9
+  },
+  "path-H961.4": {
+    "coordinates": [
+      -73.57909,
+      45.497028
+    ],
+    "floor": 9
+  },
+  "path-H9stairs1": {
+    "coordinates": [
+      -73.578689,
+      45.497307
+    ],
+    "floor": 9
+  },
+  "H964.1": {
+    "coordinates": [
+      -73.579092,
+      45.49716
+    ],
+    "floor": 9
+  },
+  "H960.2": {
+    "coordinates": [
+      -73.57887,
+      45.497229
+    ],
+    "floor": 9
+  },
+  "H845": {
+    "coordinates": [
+      -73.578786,
+      45.49705
+    ],
+    "floor": 8
+  },
+  "H8wbath": {
+    "coordinates": [
+      -73.579214,
+      45.497285
+    ],
+    "floor": 8
+  },
+  "path-H933": {
+    "coordinates": [
+      -73.578501,
+      45.497273
+    ],
+    "floor": 9
+  },
+  "H813": {
+    "coordinates": [
+      -73.579058,
+      45.49753
+    ],
+    "floor": 8
+  },
+  "H961.28": {
+    "coordinates": [
+      -73.57877,
+      45.496998
+    ],
+    "floor": 9
+  },
+  "path-elevatorH2": {
+    "coordinates": [
+      -73.578878,
+      45.497396
+    ],
+    "floor": 2
+  },
+  "DownH8escalator": {
+    "coordinates": [
+      -73.57887,
+      45.497187
+    ],
+    "floor": 8
+  },
+  "H980": {
+    "coordinates": [
+      -73.578671,
+      45.49738
+    ],
+    "floor": 9
+  },
+  "escalator-down2H2": {
+    "coordinates": [
+      -73.578871,
+      45.49725
+    ],
+    "floor": 2
+  },
+  "path-H819": {
+    "coordinates": [
+      -73.578953,
+      45.497567
+    ],
+    "floor": 8
+  },
+  "H833": {
+    "coordinates": [
+      -73.578501,
+      45.497342
+    ],
+    "floor": 8
+  },
+  "H811": {
+    "coordinates": [
+      -73.57911,
+      45.497477
+    ],
+    "floor": 8
+  },
+  "H843": {
+    "coordinates": [
+      -73.578745,
+      45.497091
+    ],
+    "floor": 8
+  },
+  "path-H8stairs2": {
+    "coordinates": [
+      -73.578598,
+      45.497294
+    ],
+    "floor": 8
+  },
+  "path-H967": {
+    "coordinates": [
+      -73.579241,
+      45.49722
+    ],
+    "floor": 9
+  },
+  "path-H902": {
+    "coordinates": [
+      -73.579187,
+      45.497294
+    ],
+    "floor": 9
+  },
+  "path-H981.2": {
+    "coordinates": [
+      -73.578813,
+      45.497184
+    ],
+    "floor": 9
+  },
+  "path-H847": {
+    "coordinates": [
+      -73.57886,
+      45.497013
+    ],
+    "floor": 8
+  },
+  "path-H827": {
+    "coordinates": [
+      -73.578661,
+      45.497432
+    ],
+    "floor": 8
+  },
+  "path-H841-H837": {
+    "coordinates": [
+      -73.578693,
+      45.497191
+    ],
+    "floor": 8
+  },
+  "path-H909": {
+    "coordinates": [
+      -73.579156,
+      45.497325
+    ],
+    "floor": 9
+  },
+  "H9stairs2": {
+    "coordinates": [
+      -73.578881,
+      45.497098
+    ],
+    "floor": 9
+  },
+  "H933": {
+    "coordinates": [
+      -73.578484,
+      45.497266
+    ],
+    "floor": 9
+  },
+  "H907": {
+    "coordinates": [
+      -73.579215,
+      45.497297
+    ],
+    "floor": 9
+  },
+  "path-H992": {
+    "coordinates": [
+      -73.579016,
+      45.497261
+    ],
+    "floor": 9
+  },
+  "H920": {
+    "coordinates": [
+      -73.578711,
+      45.497395
+    ],
+    "floor": 9
+  },
+  "H975": {
+    "coordinates": [
+      -73.578858,
+      45.497124
+    ],
+    "floor": 9
+  },
+  "path-H9stairs2": {
+    "coordinates": [
+      -73.578892,
+      45.497104
+    ],
+    "floor": 9
+  },
+  "H961.26": {
+    "coordinates": [
+      -73.57887,
+      45.49693
+    ],
+    "floor": 9
+  },
+  "path-H981": {
+    "coordinates": [
+      -73.578748,
+      45.497153
+    ],
+    "floor": 9
+  },
+  "path-H829": {
+    "coordinates": [
+      -73.578585,
+      45.497398
+    ],
+    "floor": 8
+  },
+  "H925.1": {
+    "coordinates": [
+      -73.578705,
+      45.49744
+    ],
+    "floor": 9
+  },
+  "H961.15": {
+    "coordinates": [
+      -73.578896,
+      45.496917
+    ],
+    "floor": 9
+  },
+  "path-H823": {
+    "coordinates": [
+      -73.578808,
+      45.497501
+    ],
+    "floor": 8
+  },
+  "H913": {
+    "coordinates": [
+      -73.579087,
+      45.497444
+    ],
+    "floor": 9
+  },
+  "path-H837": {
+    "coordinates": [
+      -73.578643,
+      45.497245
+    ],
+    "floor": 8
+  },
+  "escalator-upH1": {
+    "coordinates": [
+      -73.57869,
+      45.497279
+    ],
+    "floor": 1
+  },
+  "H983": {
+    "coordinates": [
+      -73.57872,
+      45.497152
+    ],
+    "floor": 9
+  },
+  "path-H8stairs4-H8elevator-H861-59-UpH8escalator": {
+    "coordinates": [
+      -73.579099,
+      45.497208
+    ],
+    "floor": 8
+  },
+  "H928": {
+    "coordinates": [
+      -73.578517,
+      45.49731
+    ],
+    "floor": 9
+  },
+  "path-H863": {
+    "coordinates": [
+      -73.579303,
+      45.497198
+    ],
+    "floor": 8
+  },
+  "H817": {
+    "coordinates": [
+      -73.578987,
+      45.497618
+    ],
+    "floor": 8
+  },
+  "H961.13": {
+    "coordinates": [
+      -73.578928,
+      45.496933
+    ],
+    "floor": 9
+  },
+  "path-H903.2": {
+    "coordinates": [
+      -73.579254,
+      45.497227
+    ],
+    "floor": 9
+  },
+  "H981": {
+    "coordinates": [
+      -73.57876,
+      45.497142
+    ],
+    "floor": 9
+  },
+  "path-H932": {
+    "coordinates": [
+      -73.578519,
+      45.497253
+    ],
+    "floor": 9
+  },
+  "H961.21": {
+    "coordinates": [
+      -73.578822,
+      45.496903
+    ],
+    "floor": 9
+  },
+  "H110": {
+    "coordinates": [
+      -73.578824,
+      45.496953
+    ],
+    "floor": 1
+  },
+  "H961.29": {
+    "coordinates": [
+      -73.578722,
+      45.497004
+    ],
+    "floor": 9
+  },
+  "path-H8stairs1": {
+    "coordinates": [
+      -73.579041,
+      45.49751
+    ],
+    "floor": 8
+  },
+  "path-H835": {
+    "coordinates": [
+      -73.57859,
+      45.497302
+    ],
+    "floor": 8
+  },
+  "path-H961.21": {
+    "coordinates": [
+      -73.578837,
+      45.49691
+    ],
+    "floor": 9
+  },
+  "H823": {
+    "coordinates": [
+      -73.578788,
+      45.497524
+    ],
+    "floor": 8
+  },
+  "escalator-downH1": {
+    "coordinates": [
+      -73.57871,
+      45.497256
+    ],
+    "floor": 1
+  },
+  "path-H963": {
+    "coordinates": [
+      -73.579117,
+      45.497161
+    ],
+    "floor": 9
+  },
+  "H961.31": {
+    "coordinates": [
+      -73.578695,
+      45.497031
+    ],
+    "floor": 9
+  },
+  "H998": {
+    "coordinates": [
+      -73.579086,
+      45.497208
+    ],
+    "floor": 9
+  },
+  "H911": {
+    "coordinates": [
+      -73.579136,
+      45.497392
+    ],
+    "floor": 9
+  },
+  "H903": {
+    "coordinates": [
+      -73.579322,
+      45.497244
+    ],
+    "floor": 9
+  },
+  "path-H965": {
+    "coordinates": [
+      -73.579184,
+      45.497193
+    ],
+    "floor": 9
+  },
+  "H937.1": {
+    "coordinates": [
+      -73.578703,
+      45.497214
+    ],
+    "floor": 9
+  },
+  "H961.23": {
+    "coordinates": [
+      -73.578802,
+      45.496923
+    ],
+    "floor": 9
+  },
+  "path-H961.25": {
+    "coordinates": [
+      -73.578791,
+      45.496955
+    ],
+    "floor": 9
+  },
+  "path-H920": {
+    "coordinates": [
+      -73.578694,
+      45.497411
+    ],
+    "floor": 9
+  },
+  "H925.3": {
+    "coordinates": [
+      -73.578674,
+      45.497424
+    ],
+    "floor": 9
+  },
+  "path-UpH9escalator": {
+    "coordinates": [
+      -73.578934,
+      45.497297
+    ],
+    "floor": 9
+  },
+  "H9mbath": {
+    "coordinates": [
+      -73.579018,
+      45.497438
+    ],
+    "floor": 9
+  },
+  "Hall-principal-entrance": {
+    "coordinates": [
+      -73.578656,
+      45.496995
+    ],
+    "floor": 0
+  },
+  "H932": {
+    "coordinates": [
+      -73.578529,
+      45.497257
+    ],
+    "floor": 9
+  },
+  "path-escalatorH1": {
+    "coordinates": [
+      -73.578685,
+      45.497258
+    ],
+    "floor": 1
+  },
+  "H8stairs2": {
+    "coordinates": [
+      -73.578622,
+      45.497305
+    ],
+    "floor": 8
+  },
+  "path-H937.1.2": {
+    "coordinates": [
+      -73.57871,
+      45.497287
+    ],
+    "floor": 9
+  },
+  "path-H914.2": {
+    "coordinates": [
+      -73.578966,
+      45.497312
+    ],
+    "floor": 9
+  },
+  "path-H919": {
+    "coordinates": [
+      -73.578932,
+      45.497527
+    ],
+    "floor": 9
+  },
+  "path-H843": {
+    "coordinates": [
+      -73.578775,
+      45.497106
+    ],
+    "floor": 8
+  },
+  "path-H855": {
+    "coordinates": [
+      -73.578993,
+      45.497051
+    ],
+    "floor": 8
+  },
+  "path-H983": {
+    "coordinates": [
+      -73.578728,
+      45.497143
+    ],
+    "floor": 9
+  },
+  "H8elevator": {
+    "coordinates": [
+      -73.57912,
+      45.497229
+    ],
+    "floor": 8
+  },
+  "H909": {
+    "coordinates": [
+      -73.579177,
+      45.497335
+    ],
+    "floor": 9
+  }
+}

--- a/myApp/app/components/IndoorMap/GraphAndCoordinates/Loyola.js
+++ b/myApp/app/components/IndoorMap/GraphAndCoordinates/Loyola.js
@@ -1,0 +1,1911 @@
+export const loyolaGraph = {
+  "path-VE225": {
+    "VE225": 2,
+    "path-VE229": 5,
+    "path-VE224": 5
+  },
+  "VL109": {
+    "path-VL112-09-13-08": 3
+  },
+  "path-VL103.1": {
+    "path-VL103-56": 17,
+    "path-VL103": 13,
+    "path-VL104": 21
+  },
+  "VE2mbath": {
+    "path-VE2mbath": 2
+  },
+  "path-VL104": {
+    "VL104": 4,
+    "path-VL105": 4,
+    "path-VL103.1": 21
+  },
+  "path-VL149": {
+    "VL149": 2,
+    "path-VL150": 6,
+    "path-VL1.1elevator": 5
+  },
+  "VL209": {
+    "path-VL209": 3
+  },
+  "VL212": {
+    "path-VL212": 4
+  },
+  "VL1stairs": {
+    "path-VL1stairs": 1,
+    "VL2stairs2": 131,
+    "VL2stairs": 110,
+    "path-VL1elevator": 32
+  },
+  "VL216": {
+    "path-VL216": 1
+  },
+  "VL202": {
+    "path-VL202": 3
+  },
+  "path-VL2wbath": {
+    "VL2wbath": 5,
+    "path-VL209": 2,
+    "path-VL2mbath": 5,
+    "path-VL2stairs": 2
+  },
+  "path-VL217": {
+    "VL217": 4,
+    "path-VL218": 6,
+    "path-VL2mbath": 4,
+    "path-VL216": 6
+  },
+  "path-VE103": {
+    "path-VE1stairs": 2,
+    "VE103": 3
+  },
+  "VL1wbath": {
+    "path-VL1wbath": 2
+  },
+  "path-VL1stairs": {
+    "VL1stairs": 1,
+    "path-VL1mbath": 2,
+    "path-VL1wbath": 2,
+    "path-VL144": 23,
+    "path-VL145": 31
+  },
+  "VE1stairs": {
+    "path-VE1stairs": 3
+  },
+  "VE2wbath": {
+    "path-VE2wbath": 2
+  },
+  "VL219": {
+    "path-VL219": 3
+  },
+  "path-VL111": {
+    "path-VL110": 4,
+    "path-VL112-09-13-08": 4,
+    "VL111": 1
+  },
+  "VL156": {
+    "path-VL156": 3
+  },
+  "path-VE210": {
+    "VE210": 2,
+    "path-VE211": 2,
+    "path-VE2stairs-212.1-15-16": 2
+  },
+  "VL130": {
+    "path-VL130": 1
+  },
+  "path-VE2mbath": {
+    "VE2mbath": 2,
+    "path-VE2wbath": 4,
+    "path-VE230": 4,
+    "path-VE201-02.1-02.2-03-04-05": 8
+  },
+  "VL2wbath": {
+    "path-VL2wbath": 5
+  },
+  "VL104": {
+    "path-VL104": 4
+  },
+  "path-VL110": {
+    "path-VL111": 4,
+    "VL110": 1,
+    "path-VL110.2": 5,
+    "path-VL114": 15
+  },
+  "VL116": {
+    "path-VL116": 4
+  },
+  "path-VL220": {
+    "VL220": 5,
+    "path-VL204": 9,
+    "path-VL219": 16
+  },
+  "VL114": {
+    "path-VL114": 3
+  },
+  "VE202.1": {
+    "path-VE201-02.1-02.2-03-04-05": 2
+  },
+  "VL105": {
+    "path-VL105": 4
+  },
+  "path-VL1mbath": {
+    "path-VL1stairs": 2,
+    "path-VL130-44-17-VL1mbath": 4,
+    "VL1mbath": 2
+  },
+  "VL222": {
+    "path-VL222": 3
+  },
+  "VL133": {
+    "path-VL133": 2
+  },
+  "path-VL130-44-17-VL1mbath": {
+    "path-VL1mbath": 4,
+    "path-VL117": 5,
+    "path-VL130": 12,
+    "path-VL144.2": 10
+  },
+  "VL154": {
+    "path-VL154": 3
+  },
+  "path-VL112-09-13-08": {
+    "VL109": 3,
+    "path-VL111": 4,
+    "VL112": 2,
+    "VL113": 2,
+    "VL108": 2
+  },
+  "VL2elevator": {
+    "path-VL2elevator": 1,
+    "VL1elevator": 130
+  },
+  "path-VL150": {
+    "path-VL149": 6,
+    "VL150": 2,
+    "path-VL150.1": 1
+  },
+  "path-VL131": {
+    "path-VL130": 13,
+    "VL131": 1,
+    "path-VL142": 2
+  },
+  "path-VL138": {
+    "path-VL132": 2,
+    "VL138": 2,
+    "path-VL139": 17
+  },
+  "path-VL212-05-14": {
+    "path-VL214": 5,
+    "path-VL212": 18,
+    "path-VL205": 44,
+    "path-VL219": 43
+  },
+  "VL144": {
+    "path-VL144": 2
+  },
+  "path-VL114.1": {
+    "path-VL114": 5,
+    "path-VL110.3": 8
+  },
+  "VE203": {
+    "path-VE201-02.1-02.2-03-04-05": 3
+  },
+  "VL103": {
+    "path-VL103": 3
+  },
+  "path-VL205": {
+    "path-VL212-05-14": 44,
+    "VL205": 2,
+    "path-VL202": 4
+  },
+  "path-VL115": {
+    "VL115": 3,
+    "path-VL114": 4,
+    "path-VL116": 3
+  },
+  "path-VL110.2": {
+    "path-VL110": 5,
+    "path-VL107.2": 9,
+    "path-VL110.3": 3
+  },
+  "VE202.2": {
+    "path-VE201-02.1-02.2-03-04-05": 3
+  },
+  "path-VL118": {
+    "path-VL118.1": 8,
+    "VL118": 3,
+    "path-VL129": 3
+  },
+  "VL145": {
+    "path-VL145": 3
+  },
+  "VE213": {
+    "path-VE213": 1
+  },
+  "path-VL2mbath": {
+    "path-VL2wbath": 5,
+    "path-VL217": 4,
+    "VL2mbath": 5,
+    "path-VL218": 10,
+    "path-VL2stairs": 2
+  },
+  "path-VE229": {
+    "path-VE225": 5,
+    "VE229": 2,
+    "path-VE230": 4
+  },
+  "path-VE230": {
+    "path-VE2mbath": 4,
+    "path-VE229": 4,
+    "VE230": 2,
+    "path-VE2wbath": 8
+  },
+  "VE201": {
+    "path-VE201-02.1-02.2-03-04-05": 2
+  },
+  "VE215": {
+    "path-VE2stairs-212.1-15-16": 3
+  },
+  "VL111": {
+    "path-VL111": 1
+  },
+  "VE230": {
+    "path-VE230": 2
+  },
+  "VL2stairs2": {
+    "VL1stairs": 131,
+    "path-VL2stairs": 2
+  },
+  "path-VE224": {
+    "path-VE225": 5,
+    "VE224": 2,
+    "path-VE221": 4
+  },
+  "path-VL203": {
+    "VL203": 2,
+    "path-VL223": 21
+  },
+  "path-VL215": {
+    "VL215": 1,
+    "path-VL223": 6,
+    "path-VL216": 5
+  },
+  "VE210": {
+    "path-VE210": 2
+  },
+  "path-VL219": {
+    "VL219": 3,
+    "path-VL220": 16,
+    "path-VL212-05-14": 43,
+    "path-VL218": 5,
+    "path-VL2stairs": 17
+  },
+  "path-VL133": {
+    "VL133": 2,
+    "path-VL125": 6,
+    "path-VL139": 4
+  },
+  "path-VL129": {
+    "path-VL118": 3,
+    "VL129": 2,
+    "path-VL125": 4
+  },
+  "path-VL209": {
+    "VL209": 3,
+    "path-VL2wbath": 2
+  },
+  "path-VL144.2": {
+    "path-VL130-44-17-VL1mbath": 10,
+    "path-VL144": 17
+  },
+  "path-VL156": {
+    "VL156": 3,
+    "path-VL155": 4,
+    "path-VL103-56": 8
+  },
+  "path-VL222": {
+    "VL222": 3,
+    "path-VL204": 3,
+    "path-VL202": 3
+  },
+  "VE2stairs": {
+    "path-VE1stairs": 134,
+    "path-VE2stairs-212.1-15-16": 3
+  },
+  "path-VL132": {
+    "path-VL138": 2,
+    "VL132": 3
+  },
+  "VL1stairs1": {
+    "path-VL1stairs1": 2
+  },
+  "VE217": {
+    "path-VE217": 2
+  },
+  "path-VL144": {
+    "VL144": 2,
+    "path-VL144.2": 17,
+    "path-VL1stairs": 23,
+    "path-VL1stairs1": 8
+  },
+  "VL153": {
+    "path-VL153": 3
+  },
+  "VL1mbath": {
+    "path-VL1mbath": 2
+  },
+  "VL132": {
+    "path-VL132": 3
+  },
+  "path-VE212": {
+    "VE212": 1,
+    "path-VE213": 4,
+    "path-VE211": 3
+  },
+  "VE216": {
+    "path-VE2stairs-212.1-15-16": 2
+  },
+  "VL217": {
+    "path-VL217": 4
+  },
+  "VE204": {
+    "path-VE201-02.1-02.2-03-04-05": 2
+  },
+  "path-VE211": {
+    "path-VE210": 2,
+    "path-VE212": 3,
+    "VE211": 1
+  },
+  "path-VL105.1": {
+    "path-VL105": 5,
+    "path-VL107": 12
+  },
+  "VE224": {
+    "path-VE224": 2
+  },
+  "VL2stairs": {
+    "path-VL2stairs": 31,
+    "VL1stairs": 110
+  },
+  "VE212": {
+    "path-VE212": 1
+  },
+  "VE225": {
+    "path-VE225": 2
+  },
+  "path-VL103": {
+    "path-VL103.1": 13,
+    "VL103": 3
+  },
+  "VL218": {
+    "path-VL218": 3
+  },
+  "VL118": {
+    "path-VL118": 3
+  },
+  "path-VL155": {
+    "path-VL156": 4,
+    "path-VL154": 4,
+    "VL155": 3
+  },
+  "VL150": {
+    "path-VL150": 2
+  },
+  "path-VL2stairs": {
+    "VL2stairs2": 2,
+    "path-VL219": 17,
+    "VL2stairs": 31,
+    "path-VL2.1elevator": 36,
+    "path-VL2mbath": 2,
+    "path-VL2wbath": 2
+  },
+  "VE101": {
+    "path-VE101": 1
+  },
+  "path-VL204": {
+    "path-VL220": 9,
+    "path-VL222": 3,
+    "VL204": 3
+  },
+  "VL129": {
+    "path-VL129": 2
+  },
+  "path-VE218": {
+    "VE218": 2,
+    "path-VE221": 2,
+    "path-VE217": 7
+  },
+  "path-VL125": {
+    "path-VL133": 6,
+    "path-VL129": 4,
+    "VL125": 2
+  },
+  "path-VL152": {
+    "path-VL153": 5,
+    "VL152": 3,
+    "path-VL150.1": 1
+  },
+  "path-VL116": {
+    "VL116": 4,
+    "path-VL115": 3,
+    "path-VL117": 1
+  },
+  "path-VL150.1": {
+    "path-VL150": 1,
+    "path-VL152": 1
+  },
+  "path-VL223": {
+    "path-VL203": 21,
+    "path-VL215": 6,
+    "VL223": 1
+  },
+  "path-VL105": {
+    "path-VL104": 4,
+    "VL105": 4,
+    "path-VL105.1": 5,
+    "path-VL105": 0
+  },
+  "VL220": {
+    "path-VL220": 5
+  },
+  "path-VL202": {
+    "VL202": 3,
+    "path-VL205": 4,
+    "path-VL222": 3
+  },
+  "path-VE201-02.1-02.2-03-04-05": {
+    "VE202.1": 2,
+    "VE203": 3,
+    "VE202.2": 3,
+    "VE201": 2,
+    "VE204": 2,
+    "VE205": 2,
+    "path-VE2mbath": 8,
+    "path-VE2wbath": 8
+  },
+  "path-VL154": {
+    "VL154": 3,
+    "path-VL155": 4,
+    "path-VL153": 4
+  },
+  "VL149": {
+    "path-VL149": 2
+  },
+  "VE103": {
+    "path-VE103": 3
+  },
+  "path-VE2stairs-212.1-15-16": {
+    "path-VE210": 2,
+    "VE215": 3,
+    "VE216": 2,
+    "VE2stairs": 3,
+    "path-VE217": 5
+  },
+  "path-VL1elevator": {
+    "path-VL145": 4,
+    "VL1stairs": 32,
+    "path-VL1.1elevator": 8,
+    "VL1elevator": 3
+  },
+  "path-VL142": {
+    "path-VL131": 2,
+    "VL142": 1
+  },
+  "VE205": {
+    "path-VE201-02.1-02.2-03-04-05": 2
+  },
+  "path-VL114": {
+    "VL114": 3,
+    "path-VL114.1": 5,
+    "path-VL115": 4,
+    "path-VL110": 15
+  },
+  "path-VL218": {
+    "path-VL217": 6,
+    "path-VL2mbath": 10,
+    "path-VL219": 5,
+    "VL218": 3
+  },
+  "VL205": {
+    "path-VL205": 2
+  },
+  "VL139": {
+    "path-VL139": 2
+  },
+  "VL2mbath": {
+    "path-VL2mbath": 5
+  },
+  "VL107": {
+    "path-VL107": 4
+  },
+  "VL110": {
+    "path-VL110": 1
+  },
+  "path-VL107.2": {
+    "path-VL110.2": 9,
+    "path-VL107": 6
+  },
+  "VE229": {
+    "path-VE229": 2
+  },
+  "path-VL117": {
+    "path-VL130-44-17-VL1mbath": 5,
+    "path-VL116": 1,
+    "VL117": 4
+  },
+  "path-VE1stairs": {
+    "path-VE103": 2,
+    "VE1stairs": 3,
+    "VE2stairs": 134,
+    "path-VE101": 2
+  },
+  "VE211": {
+    "path-VE211": 1
+  },
+  "path-VL2.1elevator": {
+    "path-VL2stairs": 36,
+    "path-VL2elevator": 4
+  },
+  "path-VL107": {
+    "path-VL105.1": 12,
+    "VL107": 4,
+    "path-VL107.2": 6
+  },
+  "path-VL110.3": {
+    "path-VL114.1": 8,
+    "path-VL110.2": 3
+  },
+  "path-VL1stairs1": {
+    "VL1stairs1": 2,
+    "path-VL144": 8,
+    "path-VL145": 0
+  },
+  "VL131": {
+    "path-VL131": 1
+  },
+  "path-VL153": {
+    "VL153": 3,
+    "path-VL152": 5,
+    "path-VL154": 4
+  },
+  "VL108": {
+    "path-VL112-09-13-08": 2
+  },
+  "VL113": {
+    "path-VL112-09-13-08": 2
+  },
+  "path-VL2elevator": {
+    "VL2elevator": 1,
+    "path-VL2.1elevator": 4,
+    "path-VL212": 5
+  },
+  "path-VL1.1elevator": {
+    "path-VL149": 5,
+    "path-VL1elevator": 8
+  },
+  "path-VL130": {
+    "VL130": 1,
+    "path-VL130-44-17-VL1mbath": 12,
+    "path-VL131": 13
+  },
+  "VL223": {
+    "path-VL223": 1
+  },
+  "path-VE217": {
+    "VE217": 2,
+    "path-VE218": 7,
+    "path-VE2stairs-212.1-15-16": 5
+  },
+  "path-VL1wbath": {
+    "VL1wbath": 2,
+    "path-VL1stairs": 2,
+    "path-VL118.1": 5
+  },
+  "path-VL145": {
+    "VL145": 3,
+    "path-VL1elevator": 4,
+    "path-VL1stairs1": 0,
+    "path-VL1stairs": 31
+  },
+  "VL155": {
+    "path-VL155": 3
+  },
+  "VL117": {
+    "path-VL117": 4
+  },
+  "path-VL103-56": {
+    "path-VL103.1": 17,
+    "path-VL156": 8
+  },
+  "VL152": {
+    "path-VL152": 3
+  },
+  "VL142": {
+    "path-VL142": 1
+  },
+  "VL112": {
+    "path-VL112-09-13-08": 2
+  },
+  "VE221": {
+    "path-VE221": 2
+  },
+  "path-VL201": {
+    "VL201": 2,
+    "path-VL214": 14
+  },
+  "VL214": {
+    "path-VL214": 1
+  },
+  "VL125": {
+    "path-VL125": 2
+  },
+  "path-VL216": {
+    "VL216": 1,
+    "path-VL215": 5,
+    "path-VL217": 6
+  },
+  "path-VL212": {
+    "VL212": 4,
+    "path-VL212-05-14": 18,
+    "path-VL2elevator": 5
+  },
+  "VL215": {
+    "path-VL215": 1
+  },
+  "VL204": {
+    "path-VL204": 3
+  },
+  "VL201": {
+    "path-VL201": 2
+  },
+  "VL138": {
+    "path-VL138": 2
+  },
+  "path-VE221": {
+    "path-VE224": 4,
+    "path-VE218": 2,
+    "VE221": 2
+  },
+  "path-VE213": {
+    "VE213": 1,
+    "path-VE212": 4
+  },
+  "VL1elevator": {
+    "VL2elevator": 130,
+    "path-VL1elevator": 3
+  },
+  "path-VL139": {
+    "path-VL138": 17,
+    "path-VL133": 4,
+    "VL139": 2
+  },
+  "path-VL118.1": {
+    "path-VL118": 8,
+    "path-VL1wbath": 5
+  },
+  "VL115": {
+    "path-VL115": 3
+  },
+  "VE218": {
+    "path-VE218": 2
+  },
+  "path-VL214": {
+    "path-VL212-05-14": 5,
+    "path-VL201": 14,
+    "VL214": 1
+  },
+  "path-VE101": {
+    "VE101": 1,
+    "path-VE1stairs": 2
+  },
+  "path-VE2wbath": {
+    "VE2wbath": 2,
+    "path-VE2mbath": 4,
+    "path-VE230": 8,
+    "path-VE201-02.1-02.2-03-04-05": 8
+  },
+  "VL203": {
+    "path-VL203": 2
+  }
+}
+
+export const loyolaNodeCoordinates = {
+  "path-VE225": {
+    "coordinates": [
+      -73.638616,
+      45.458758
+    ],
+    "floor": 2
+  },
+  "VL109": {
+    "coordinates": [
+      -73.637258,
+      45.458581
+    ],
+    "floor": 1
+  },
+  "path-VL103.1": {
+    "coordinates": [
+      -73.636735,
+      45.458406
+    ],
+    "floor": 1
+  },
+  "VE2mbath": {
+    "coordinates": [
+      -73.638485,
+      45.458687
+    ],
+    "floor": 2
+  },
+  "path-VL104": {
+    "coordinates": [
+      -73.636974,
+      45.458495
+    ],
+    "floor": 1
+  },
+  "path-VL149": {
+    "coordinates": [
+      -73.636782,
+      45.458311
+    ],
+    "floor": 1
+  },
+  "VL209": {
+    "coordinates": [
+      -73.638767,
+      45.458857
+    ],
+    "floor": 2
+  },
+  "VL212": {
+    "coordinates": [
+      -73.638182,
+      45.458896
+    ],
+    "floor": 2
+  },
+  "VL1stairs": {
+    "coordinates": [
+      -73.637289,
+      45.458219
+    ],
+    "floor": 1
+  },
+  "VL216": {
+    "coordinates": [
+      -73.63872,
+      45.458972
+    ],
+    "floor": 2
+  },
+  "VL202": {
+    "coordinates": [
+      -73.638593,
+      45.459239
+    ],
+    "floor": 2
+  },
+  "path-VL2wbath": {
+    "coordinates": [
+      -73.638716,
+      45.458867
+    ],
+    "floor": 2
+  },
+  "path-VL217": {
+    "coordinates": [
+      -73.638661,
+      45.458934
+    ],
+    "floor": 2
+  },
+  "path-VE103": {
+    "coordinates": [
+      -73.63747,
+      45.458194
+    ],
+    "floor": 1
+  },
+  "VL1wbath": {
+    "coordinates": [
+      -73.637341,
+      45.458218
+    ],
+    "floor": 1
+  },
+  "path-VL1stairs": {
+    "coordinates": [
+      -73.637305,
+      45.458226
+    ],
+    "floor": 1
+  },
+  "VE1stairs": {
+    "coordinates": [
+      -73.637473,
+      45.458224
+    ],
+    "floor": 1
+  },
+  "VE2wbath": {
+    "coordinates": [
+      -73.638435,
+      45.458667
+    ],
+    "floor": 2
+  },
+  "VL219": {
+    "coordinates": [
+      -73.638629,
+      45.459025
+    ],
+    "floor": 2
+  },
+  "path-VL111": {
+    "coordinates": [
+      -73.637258,
+      45.458528
+    ],
+    "floor": 1
+  },
+  "VL156": {
+    "coordinates": [
+      -73.636562,
+      45.458406
+    ],
+    "floor": 1
+  },
+  "path-VE210": {
+    "coordinates": [
+      -73.638864,
+      45.45888
+    ],
+    "floor": 2
+  },
+  "VL130": {
+    "coordinates": [
+      -73.637141,
+      45.458218
+    ],
+    "floor": 1
+  },
+  "path-VE2mbath": {
+    "coordinates": [
+      -73.638473,
+      45.458702
+    ],
+    "floor": 2
+  },
+  "VL2wbath": {
+    "coordinates": [
+      -73.638708,
+      45.458911
+    ],
+    "floor": 2
+  },
+  "VL104": {
+    "coordinates": [
+      -73.637014,
+      45.45851
+    ],
+    "floor": 1
+  },
+  "path-VL110": {
+    "coordinates": [
+      -73.637282,
+      45.458497
+    ],
+    "floor": 1
+  },
+  "VL116": {
+    "coordinates": [
+      -73.637369,
+      45.458316
+    ],
+    "floor": 1
+  },
+  "path-VL220": {
+    "coordinates": [
+      -73.638497,
+      45.459147
+    ],
+    "floor": 2
+  },
+  "VL114": {
+    "coordinates": [
+      -73.637299,
+      45.45837
+    ],
+    "floor": 1
+  },
+  "VE202.1": {
+    "coordinates": [
+      -73.638374,
+      45.458751
+    ],
+    "floor": 2
+  },
+  "VL105": {
+    "coordinates": [
+      -73.637043,
+      45.458476
+    ],
+    "floor": 1
+  },
+  "path-VL1mbath": {
+    "coordinates": [
+      -73.637291,
+      45.458244
+    ],
+    "floor": 1
+  },
+  "VL222": {
+    "coordinates": [
+      -73.638609,
+      45.459217
+    ],
+    "floor": 2
+  },
+  "VL133": {
+    "coordinates": [
+      -73.637352,
+      45.458122
+    ],
+    "floor": 1
+  },
+  "path-VL130-44-17-VL1mbath": {
+    "coordinates": [
+      -73.637266,
+      45.458274
+    ],
+    "floor": 1
+  },
+  "VL154": {
+    "coordinates": [
+      -73.636607,
+      45.458345
+    ],
+    "floor": 1
+  },
+  "path-VL112-09-13-08": {
+    "coordinates": [
+      -73.637232,
+      45.458562
+    ],
+    "floor": 1
+  },
+  "VL2elevator": {
+    "coordinates": [
+      -73.638221,
+      45.458935
+    ],
+    "floor": 2
+  },
+  "path-VL150": {
+    "coordinates": [
+      -73.636712,
+      45.458284
+    ],
+    "floor": 1
+  },
+  "path-VL131": {
+    "coordinates": [
+      -73.63699,
+      45.458168
+    ],
+    "floor": 1
+  },
+  "path-VL138": {
+    "coordinates": [
+      -73.637106,
+      45.458046
+    ],
+    "floor": 1
+  },
+  "path-VL212-05-14": {
+    "coordinates": [
+      -73.638045,
+      45.45907
+    ],
+    "floor": 2
+  },
+  "VL144": {
+    "coordinates": [
+      -73.637031,
+      45.458259
+    ],
+    "floor": 1
+  },
+  "path-VL114.1": {
+    "coordinates": [
+      -73.637237,
+      45.458402
+    ],
+    "floor": 1
+  },
+  "VE203": {
+    "coordinates": [
+      -73.638404,
+      45.458776
+    ],
+    "floor": 2
+  },
+  "VL103": {
+    "coordinates": [
+      -73.6367,
+      45.458523
+    ],
+    "floor": 1
+  },
+  "path-VL205": {
+    "coordinates": [
+      -73.638536,
+      45.459256
+    ],
+    "floor": 2
+  },
+  "path-VL115": {
+    "coordinates": [
+      -73.637297,
+      45.458325
+    ],
+    "floor": 1
+  },
+  "path-VL110.2": {
+    "coordinates": [
+      -73.637309,
+      45.458461
+    ],
+    "floor": 1
+  },
+  "VE202.2": {
+    "coordinates": [
+      -73.638379,
+      45.458774
+    ],
+    "floor": 2
+  },
+  "path-VL118": {
+    "coordinates": [
+      -73.637429,
+      45.458207
+    ],
+    "floor": 1
+  },
+  "VL145": {
+    "coordinates": [
+      -73.636879,
+      45.458223
+    ],
+    "floor": 1
+  },
+  "VE213": {
+    "coordinates": [
+      -73.638796,
+      45.45895
+    ],
+    "floor": 2
+  },
+  "path-VL2mbath": {
+    "coordinates": [
+      -73.638686,
+      45.458902
+    ],
+    "floor": 2
+  },
+  "path-VE229": {
+    "coordinates": [
+      -73.638564,
+      45.458738
+    ],
+    "floor": 2
+  },
+  "path-VE230": {
+    "coordinates": [
+      -73.638519,
+      45.45872
+    ],
+    "floor": 2
+  },
+  "VE201": {
+    "coordinates": [
+      -73.638392,
+      45.458729
+    ],
+    "floor": 2
+  },
+  "VE215": {
+    "coordinates": [
+      -73.638912,
+      45.458861
+    ],
+    "floor": 2
+  },
+  "VL111": {
+    "coordinates": [
+      -73.637271,
+      45.458533
+    ],
+    "floor": 1
+  },
+  "VE230": {
+    "coordinates": [
+      -73.63853,
+      45.458706
+    ],
+    "floor": 2
+  },
+  "VL2stairs2": {
+    "coordinates": [
+      -73.638682,
+      45.458877
+    ],
+    "floor": 2
+  },
+  "path-VE224": {
+    "coordinates": [
+      -73.638674,
+      45.458782
+    ],
+    "floor": 2
+  },
+  "path-VL203": {
+    "coordinates": [
+      -73.638719,
+      45.459169
+    ],
+    "floor": 2
+  },
+  "path-VL215": {
+    "coordinates": [
+      -73.638782,
+      45.458982
+    ],
+    "floor": 2
+  },
+  "VE210": {
+    "coordinates": [
+      -73.638846,
+      45.458875
+    ],
+    "floor": 2
+  },
+  "path-VL219": {
+    "coordinates": [
+      -73.638594,
+      45.459019
+    ],
+    "floor": 2
+  },
+  "path-VL133": {
+    "coordinates": [
+      -73.637338,
+      45.458139
+    ],
+    "floor": 1
+  },
+  "path-VL129": {
+    "coordinates": [
+      -73.637453,
+      45.458185
+    ],
+    "floor": 1
+  },
+  "path-VL209": {
+    "coordinates": [
+      -73.638729,
+      45.45885
+    ],
+    "floor": 2
+  },
+  "path-VL144.2": {
+    "coordinates": [
+      -73.637208,
+      45.45835
+    ],
+    "floor": 1
+  },
+  "path-VL156": {
+    "coordinates": [
+      -73.636595,
+      45.458419
+    ],
+    "floor": 1
+  },
+  "path-VL222": {
+    "coordinates": [
+      -73.638577,
+      45.459207
+    ],
+    "floor": 2
+  },
+  "VE2stairs": {
+    "coordinates": [
+      -73.638913,
+      45.458877
+    ],
+    "floor": 2
+  },
+  "path-VL132": {
+    "coordinates": [
+      -73.637081,
+      45.458036
+    ],
+    "floor": 1
+  },
+  "VL1stairs1": {
+    "coordinates": [
+      -73.636931,
+      45.45822
+    ],
+    "floor": 1
+  },
+  "VE217": {
+    "coordinates": [
+      -73.638826,
+      45.458826
+    ],
+    "floor": 2
+  },
+  "path-VL144": {
+    "coordinates": [
+      -73.637015,
+      45.458276
+    ],
+    "floor": 1
+  },
+  "VL153": {
+    "coordinates": [
+      -73.636627,
+      45.458317
+    ],
+    "floor": 1
+  },
+  "VL1mbath": {
+    "coordinates": [
+      -73.637312,
+      45.458251
+    ],
+    "floor": 1
+  },
+  "VL132": {
+    "coordinates": [
+      -73.637057,
+      45.45806
+    ],
+    "floor": 1
+  },
+  "path-VE212": {
+    "coordinates": [
+      -73.638832,
+      45.458922
+    ],
+    "floor": 2
+  },
+  "VE216": {
+    "coordinates": [
+      -73.638877,
+      45.458847
+    ],
+    "floor": 2
+  },
+  "VL217": {
+    "coordinates": [
+      -73.638675,
+      45.458964
+    ],
+    "floor": 2
+  },
+  "VE204": {
+    "coordinates": [
+      -73.638418,
+      45.458758
+    ],
+    "floor": 2
+  },
+  "path-VE211": {
+    "coordinates": [
+      -73.63885,
+      45.458899
+    ],
+    "floor": 2
+  },
+  "path-VL105.1": {
+    "coordinates": [
+      -73.637033,
+      45.458419
+    ],
+    "floor": 1
+  },
+  "VE224": {
+    "coordinates": [
+      -73.638686,
+      45.458769
+    ],
+    "floor": 2
+  },
+  "VL2stairs": {
+    "coordinates": [
+      -73.638301,
+      45.458904
+    ],
+    "floor": 2
+  },
+  "VE212": {
+    "coordinates": [
+      -73.638823,
+      45.458919
+    ],
+    "floor": 2
+  },
+  "VE225": {
+    "coordinates": [
+      -73.638626,
+      45.458746
+    ],
+    "floor": 2
+  },
+  "path-VL103": {
+    "coordinates": [
+      -73.636663,
+      45.458509
+    ],
+    "floor": 1
+  },
+  "VL218": {
+    "coordinates": [
+      -73.638656,
+      45.458989
+    ],
+    "floor": 2
+  },
+  "VL118": {
+    "coordinates": [
+      -73.637417,
+      45.458233
+    ],
+    "floor": 1
+  },
+  "path-VL155": {
+    "coordinates": [
+      -73.636616,
+      45.45839
+    ],
+    "floor": 1
+  },
+  "VL150": {
+    "coordinates": [
+      -73.636725,
+      45.458267
+    ],
+    "floor": 1
+  },
+  "path-VL2stairs": {
+    "coordinates": [
+      -73.638702,
+      45.458884
+    ],
+    "floor": 2
+  },
+  "VE101": {
+    "coordinates": [
+      -73.637518,
+      45.458212
+    ],
+    "floor": 1
+  },
+  "path-VL204": {
+    "coordinates": [
+      -73.638595,
+      45.459187
+    ],
+    "floor": 2
+  },
+  "VL129": {
+    "coordinates": [
+      -73.637478,
+      45.458172
+    ],
+    "floor": 1
+  },
+  "path-VE218": {
+    "coordinates": [
+      -73.638741,
+      45.458809
+    ],
+    "floor": 2
+  },
+  "path-VL125": {
+    "coordinates": [
+      -73.637408,
+      45.458167
+    ],
+    "floor": 1
+  },
+  "path-VL152": {
+    "coordinates": [
+      -73.63669,
+      45.458287
+    ],
+    "floor": 1
+  },
+  "path-VL116": {
+    "coordinates": [
+      -73.637314,
+      45.458305
+    ],
+    "floor": 1
+  },
+  "path-VL150.1": {
+    "coordinates": [
+      -73.636697,
+      45.458279
+    ],
+    "floor": 1
+  },
+  "path-VL223": {
+    "coordinates": [
+      -73.638846,
+      45.459007
+    ],
+    "floor": 2
+  },
+  "path-VL105": {
+    "coordinates": [
+      -73.637,
+      45.458459
+    ],
+    "floor": 1
+  },
+  "VL220": {
+    "coordinates": [
+      -73.638553,
+      45.459135
+    ],
+    "floor": 2
+  },
+  "path-VL202": {
+    "coordinates": [
+      -73.638561,
+      45.459227
+    ],
+    "floor": 2
+  },
+  "path-VE201-02.1-02.2-03-04-05": {
+    "coordinates": [
+      -73.6384,
+      45.458749
+    ],
+    "floor": 2
+  },
+  "path-VL154": {
+    "coordinates": [
+      -73.63664,
+      45.458357
+    ],
+    "floor": 1
+  },
+  "VL149": {
+    "coordinates": [
+      -73.636795,
+      45.458293
+    ],
+    "floor": 1
+  },
+  "VE103": {
+    "coordinates": [
+      -73.637453,
+      45.458215
+    ],
+    "floor": 1
+  },
+  "path-VE2stairs-212.1-15-16": {
+    "coordinates": [
+      -73.638876,
+      45.458863
+    ],
+    "floor": 2
+  },
+  "path-VL1elevator": {
+    "coordinates": [
+      -73.636889,
+      45.458269
+    ],
+    "floor": 1
+  },
+  "path-VL142": {
+    "coordinates": [
+      -73.636972,
+      45.458161
+    ],
+    "floor": 1
+  },
+  "VE205": {
+    "coordinates": [
+      -73.638428,
+      45.458743
+    ],
+    "floor": 2
+  },
+  "path-VL114": {
+    "coordinates": [
+      -73.63727,
+      45.45836
+    ],
+    "floor": 1
+  },
+  "path-VL218": {
+    "coordinates": [
+      -73.638626,
+      45.458977
+    ],
+    "floor": 2
+  },
+  "VL205": {
+    "coordinates": [
+      -73.638559,
+      45.459263
+    ],
+    "floor": 2
+  },
+  "VL139": {
+    "coordinates": [
+      -73.63731,
+      45.458105
+    ],
+    "floor": 1
+  },
+  "VL2mbath": {
+    "coordinates": [
+      -73.638737,
+      45.458876
+    ],
+    "floor": 2
+  },
+  "VL107": {
+    "coordinates": [
+      -73.637149,
+      45.458501
+    ],
+    "floor": 1
+  },
+  "VL110": {
+    "coordinates": [
+      -73.637294,
+      45.458502
+    ],
+    "floor": 1
+  },
+  "path-VL107.2": {
+    "coordinates": [
+      -73.63721,
+      45.458425
+    ],
+    "floor": 1
+  },
+  "VE229": {
+    "coordinates": [
+      -73.638573,
+      45.458724
+    ],
+    "floor": 2
+  },
+  "path-VL117": {
+    "coordinates": [
+      -73.637319,
+      45.458298
+    ],
+    "floor": 1
+  },
+  "path-VE1stairs": {
+    "coordinates": [
+      -73.637492,
+      45.458202
+    ],
+    "floor": 1
+  },
+  "VE211": {
+    "coordinates": [
+      -73.638841,
+      45.458897
+    ],
+    "floor": 2
+  },
+  "path-VL2.1elevator": {
+    "coordinates": [
+      -73.638259,
+      45.458964
+    ],
+    "floor": 2
+  },
+  "path-VL107": {
+    "coordinates": [
+      -73.637174,
+      45.458472
+    ],
+    "floor": 1
+  },
+  "path-VL110.3": {
+    "coordinates": [
+      -73.637328,
+      45.458437
+    ],
+    "floor": 1
+  },
+  "path-VL1stairs1": {
+    "coordinates": [
+      -73.636919,
+      45.45824
+    ],
+    "floor": 1
+  },
+  "VL131": {
+    "coordinates": [
+      -73.636997,
+      45.45816
+    ],
+    "floor": 1
+  },
+  "path-VL153": {
+    "coordinates": [
+      -73.63666,
+      45.458328
+    ],
+    "floor": 1
+  },
+  "VL108": {
+    "coordinates": [
+      -73.637224,
+      45.458545
+    ],
+    "floor": 1
+  },
+  "VL113": {
+    "coordinates": [
+      -73.637213,
+      45.458575
+    ],
+    "floor": 1
+  },
+  "path-VL2elevator": {
+    "coordinates": [
+      -73.638213,
+      45.458947
+    ],
+    "floor": 2
+  },
+  "path-VL1.1elevator": {
+    "coordinates": [
+      -73.636837,
+      45.458333
+    ],
+    "floor": 1
+  },
+  "path-VL130": {
+    "coordinates": [
+      -73.637136,
+      45.458224
+    ],
+    "floor": 1
+  },
+  "VL223": {
+    "coordinates": [
+      -73.63885,
+      45.458997
+    ],
+    "floor": 2
+  },
+  "path-VE217": {
+    "coordinates": [
+      -73.638817,
+      45.45884
+    ],
+    "floor": 2
+  },
+  "path-VL1wbath": {
+    "coordinates": [
+      -73.637318,
+      45.458209
+    ],
+    "floor": 1
+  },
+  "path-VL145": {
+    "coordinates": [
+      -73.636914,
+      45.458238
+    ],
+    "floor": 1
+  },
+  "VL155": {
+    "coordinates": [
+      -73.636583,
+      45.458378
+    ],
+    "floor": 1
+  },
+  "VL117": {
+    "coordinates": [
+      -73.637365,
+      45.458298
+    ],
+    "floor": 1
+  },
+  "path-VL103-56": {
+    "coordinates": [
+      -73.636548,
+      45.458485
+    ],
+    "floor": 1
+  },
+  "VL152": {
+    "coordinates": [
+      -73.636656,
+      45.458276
+    ],
+    "floor": 1
+  },
+  "VL142": {
+    "coordinates": [
+      -73.636965,
+      45.458171
+    ],
+    "floor": 1
+  },
+  "VL112": {
+    "coordinates": [
+      -73.637254,
+      45.458556
+    ],
+    "floor": 1
+  },
+  "VE221": {
+    "coordinates": [
+      -73.638725,
+      45.458786
+    ],
+    "floor": 2
+  },
+  "path-VL201": {
+    "coordinates": [
+      -73.6379,
+      45.459166
+    ],
+    "floor": 2
+  },
+  "VL214": {
+    "coordinates": [
+      -73.637968,
+      45.459052
+    ],
+    "floor": 2
+  },
+  "VL125": {
+    "coordinates": [
+      -73.637424,
+      45.458151
+    ],
+    "floor": 1
+  },
+  "path-VL216": {
+    "coordinates": [
+      -73.638727,
+      45.45896
+    ],
+    "floor": 2
+  },
+  "path-VL212": {
+    "coordinates": [
+      -73.63816,
+      45.458927
+    ],
+    "floor": 2
+  },
+  "VL215": {
+    "coordinates": [
+      -73.638773,
+      45.458993
+    ],
+    "floor": 2
+  },
+  "VL204": {
+    "coordinates": [
+      -73.638624,
+      45.459198
+    ],
+    "floor": 2
+  },
+  "VL201": {
+    "coordinates": [
+      -73.637874,
+      45.459161
+    ],
+    "floor": 2
+  },
+  "VL138": {
+    "coordinates": [
+      -73.637118,
+      45.458032
+    ],
+    "floor": 1
+  },
+  "path-VE221": {
+    "coordinates": [
+      -73.638715,
+      45.458799
+    ],
+    "floor": 2
+  },
+  "path-VE213": {
+    "coordinates": [
+      -73.638807,
+      45.458955
+    ],
+    "floor": 2
+  },
+  "VL1elevator": {
+    "coordinates": [
+      -73.636855,
+      45.458259
+    ],
+    "floor": 1
+  },
+  "path-VL139": {
+    "coordinates": [
+      -73.637294,
+      45.458121
+    ],
+    "floor": 1
+  },
+  "path-VL118.1": {
+    "coordinates": [
+      -73.637344,
+      45.458172
+    ],
+    "floor": 1
+  },
+  "VL115": {
+    "coordinates": [
+      -73.637331,
+      45.458338
+    ],
+    "floor": 1
+  },
+  "VE218": {
+    "coordinates": [
+      -73.638751,
+      45.458795
+    ],
+    "floor": 2
+  },
+  "path-VL214": {
+    "coordinates": [
+      -73.637984,
+      45.459058
+    ],
+    "floor": 2
+  },
+  "path-VE101": {
+    "coordinates": [
+      -73.637513,
+      45.458209
+    ],
+    "floor": 1
+  },
+  "path-VE2wbath": {
+    "coordinates": [
+      -73.638427,
+      45.458682
+    ],
+    "floor": 2
+  },
+  "VL203": {
+    "coordinates": [
+      -73.638693,
+      45.459175
+    ],
+    "floor": 2
+  }
+}

--- a/myApp/app/components/IndoorMap/GraphAndCoordinates/MB.js
+++ b/myApp/app/components/IndoorMap/GraphAndCoordinates/MB.js
@@ -1,0 +1,949 @@
+export const mbGraph = {
+  "path-MBS2.113": {
+    "path-MBS2.114": 4,
+    "MBS2.113": 5,
+    "path-elevatorMBS2": 6
+  },
+  "MB1.127": {
+    "path-MB1.127": 1
+  },
+  "MB1.102": {
+    "path-MB1.102": 2,
+    "path-MB1.210": 11
+  },
+  "path-MBS2.104": {
+    "MBS2.104": 4,
+    "path-MBS2.107": 2,
+    "path-MBS2.103": 3
+  },
+  "MBS2.129": {
+    "path-MBS2.129": 7
+  },
+  "MB1.210": {
+    "path-MB1.210": 23,
+    "MB1.210": 0,
+    "path-MB1.210.2": 2
+  },
+  "MBS2.127": {
+    "path-MBS2.128": 2
+  },
+  "MB1Escalator": {
+    "escalatorMBS2": 18,
+    "path-MB1.117": 3
+  },
+  "MB1.126": {
+    "path-MB1.126": 5
+  },
+  "MB1-entrance": {
+    "path-MB1.128.2": 7
+  },
+  "MBS2.107": {
+    "path-MBS2.107": 2
+  },
+  "elevator1MBS2": {
+    "path-elevatorMBS2": 3
+  },
+  "path-elevatorMB1": {
+    "elevatorMB1": 3,
+    "path-MB1.107": 6,
+    "PathToElevatorsMB1": 7
+  },
+  "path-MB1.210": {
+    "MB1.210": 23,
+    "MB1.101": 3,
+    "MB1.102": 11,
+    "path-stairs1MB1.3": 3,
+    "path-MB1.102": 11,
+    "path-stairs1MB1": 25
+  },
+  "MB1.108": {
+    "path-MB1.108": 1,
+    "path-MB1.107": 4
+  },
+  "path-MB1.128.2": {
+    "MB1-entrance": 7,
+    "path-MB1.128": 2,
+    "path-MB1.129": 10
+  },
+  "MB1.105": {
+    "path-MB1.105": 1
+  },
+  "path-MBS2.106": {
+    "MBS2.106": 2,
+    "MBS2.105": 4,
+    "path-MBS2.107": 1
+  },
+  "path-MBS2.125": {
+    "path-MBS2.129": 2,
+    "path-MBS2.128": 2,
+    "MBS2.125": 7
+  },
+  "path-MBS2.114": {
+    "path-MBS2.113": 4,
+    "MBS2.114": 3,
+    "MBS2Stairs1": 3
+  },
+  "escalatorMBS2": {
+    "MB1Escalator": 18,
+    "path_MBS2Stairs2": 18
+  },
+  "path-stairs1MB1.3": {
+    "path-MB1.210": 3,
+    "path-stairs1MB1.2": 26
+  },
+  "path-MB1.102": {
+    "MB1.102": 2,
+    "path-MB1.210": 11,
+    "MB1.132": 3,
+    "MB1.103": 4
+  },
+  "MBS2.131": {
+    "path-MBS2.131": 2
+  },
+  "path-MBS2.108": {
+    "path-escalatorMBS2": 6,
+    "MBS2.108": 1,
+    "path-MBS2.103": 4
+  },
+  "MB1.132": {
+    "path-MB1.102": 3
+  },
+  "MBS2.105": {
+    "path-MBS2.106": 4
+  },
+  "path-MB1.105": {
+    "MB1.105": 1,
+    "path-bathroom": 8,
+    "MB1.124": 1
+  },
+  "MB1mbath": {
+    "path-bathrrom2": 1
+  },
+  "MBS2.114": {
+    "path-MBS2.114": 3
+  },
+  "path-MB1.210.2": {
+    "MB1.210": 2,
+    "PathToElevatorsMB1": 6
+  },
+  "path-MB1.107": {
+    "path-elevatorMB1": 6,
+    "MB1.107": 1,
+    "MB1.108": 4,
+    "path-MB1.108": 4
+  },
+  "stairs1MB1": {
+    "path-stairs1MB1": 2,
+    "MBS2Stairs2": 23
+  },
+  "MBS2.125": {
+    "path-MBS2.125": 7
+  },
+  "path-escalatorMBS2": {
+    "path-MBS2.108": 6,
+    "path3-elevatorMBS2": 27,
+    "path2-escalatorMBS2": 3
+  },
+  "path-stairs1MB1": {
+    "stairs1MB1": 2,
+    "path-MB1.210": 25,
+    "path-stairs1MB1.2": 2
+  },
+  "stairs2MB": {
+    "path-MB1.108": 2,
+    "MBS2Stairs1": 6
+  },
+  "path2-escalatorMBS2": {
+    "path-escalatorMBS2": 3,
+    "path-elevatorMBS2": 31
+  },
+  "elevatorMB1": {
+    "path-elevatorMB1": 3
+  },
+  "MBS2.132": {
+    "path-MBS2.133": 4
+  },
+  "path-MBS2.103": {
+    "path-MBS2.104": 3,
+    "path-MBS2.108": 4,
+    "MBS2.103": 4
+  },
+  "path-MBS2.128": {
+    "path-MBS2.125": 2,
+    "MBS2.128": 3,
+    "MBS2.127": 2
+  },
+  "PathToElevatorsMB1": {
+    "path-elevatorMB1": 7,
+    "path-MB1.210.2": 6,
+    "path-MB1.117": 7
+  },
+  "path-bathroom": {
+    "path-MB1.105": 8,
+    "path-MB1.127": 7,
+    "path-bathrrom2": 2
+  },
+  "path-elevatorMBS2": {
+    "path-MBS2.113": 6,
+    "elevator1MBS2": 3,
+    "path2-escalatorMBS2": 31,
+    "path2-elevatorMBS2": 7
+  },
+  "path-S2.130": {
+    "MBS2.130": 2,
+    "path-MBS2.126": 2,
+    "path-MBS2.124": 3
+  },
+  "MB1.103": {
+    "path-MB1.102": 4
+  },
+  "path-MBS2.124": {
+    "path-S2.130": 3,
+    "path-MBS2.131": 5,
+    "MBS2.124": 5
+  },
+  "path2-elevatorMBS2": {
+    "path3-elevatorMBS2": 5,
+    "path-elevatorMBS2": 7,
+    "path2-MBS2.133": 20
+  },
+  "MB1.128": {
+    "path-MB1.128": 2
+  },
+  "path-MB1.108": {
+    "MB1.108": 1,
+    "stairs2MB": 2,
+    "path-MB1.107": 4
+  },
+  "MBS2.106": {
+    "path-MBS2.106": 2
+  },
+  "path_MBS2Stairs2": {
+    "escalatorMBS2": 18,
+    "MBS2Stairs2": 3
+  },
+  "MB1.107": {
+    "path-MB1.107": 1
+  },
+  "MB1.125": {
+    "path-MB1.126": 7
+  },
+  "path-MB1.126": {
+    "MB1.126": 5,
+    "MB1.125": 7,
+    "path-MB1.128": 3,
+    "path-MB1.127": 3
+  },
+  "path-MBS2.129": {
+    "MBS2.129": 7,
+    "path-MBS2.125": 2,
+    "path-MBS2.126": 5
+  },
+  "MB1.129": {
+    "path-MB1.129": 2
+  },
+  "path2-MBS2.133": {
+    "path2-elevatorMBS2": 20,
+    "path-MBS2.133": 4,
+    "path-MBS2.131": 7
+  },
+  "path-MB1.117": {
+    "MB1Escalator": 3,
+    "PathToElevatorsMB1": 7,
+    "MB1.117": 2,
+    "path-MB1.129": 4
+  },
+  "path-stairs1MB1.2": {
+    "path-stairs1MB1.3": 26,
+    "path-stairs1MB1": 2
+  },
+  "MBS2.108": {
+    "path-MBS2.108": 1
+  },
+  "MBS2Stairs2": {
+    "stairs1MB1": 23,
+    "path_MBS2Stairs2": 3
+  },
+  "MBS2.133": {
+    "path-MBS2.133": 2
+  },
+  "path-MBS2.126": {
+    "path-S2.130": 2,
+    "path-MBS2.129": 5,
+    "MBS2.126": 3
+  },
+  "MBS2.124": {
+    "path-MBS2.124": 5
+  },
+  "MBS2.126": {
+    "path-MBS2.126": 3
+  },
+  "path-MBS2.133": {
+    "MBS2.132": 4,
+    "path2-MBS2.133": 4,
+    "MBS2.133": 2
+  },
+  "path-MB1.129": {
+    "path-MB1.128.2": 10,
+    "MB1.129": 2,
+    "path-MB1.117": 4
+  },
+  "MBS2Stairs1": {
+    "path-MBS2.114": 3,
+    "stairs2MB": 6
+  },
+  "MB1.117": {
+    "path-MB1.117": 2
+  },
+  "MBS2.130": {
+    "path-S2.130": 2
+  },
+  "path-MBS2.107": {
+    "path-MBS2.104": 2,
+    "MBS2.107": 2,
+    "path-MBS2.106": 1
+  },
+  "MB1wbath": {
+    "path-bathrrom2": 1
+  },
+  "MBS2.128": {
+    "path-MBS2.128": 3
+  },
+  "MBS2.103": {
+    "path-MBS2.103": 4
+  },
+  "path-MB1.127": {
+    "MB1.127": 1,
+    "path-bathroom": 7,
+    "path-MB1.126": 3
+  },
+  "path-bathrrom2": {
+    "MB1wbath": 1,
+    "MB1mbath": 1,
+    "path-bathroom": 2
+  },
+  "path-MBS2.131": {
+    "MBS2.131": 2,
+    "path-MBS2.124": 5,
+    "path2-MBS2.133": 7
+  },
+  "MB1.124": {
+    "path-MB1.105": 1
+  },
+  "MB1.101": {
+    "path-MB1.210": 3
+  },
+  "path3-elevatorMBS2": {
+    "path-escalatorMBS2": 27,
+    "path2-elevatorMBS2": 5
+  },
+  "MBS2.113": {
+    "path-MBS2.113": 5
+  },
+  "path-MB1.128": {
+    "path-MB1.128.2": 2,
+    "MB1.128": 2,
+    "path-MB1.126": 3
+  },
+  "MBS2.104": {
+    "path-MBS2.104": 4
+  }
+}
+
+export const mbNodeCoordinates = {
+  "path-MBS2.113": {
+    "coordinates": [
+      -73.579072,
+      45.495216
+    ],
+    "floor": -2
+  },
+  "MB1.127": {
+    "coordinates": [
+      -73.579231,
+      45.495372
+    ],
+    "floor": 1
+  },
+  "MB1.102": {
+    "coordinates": [
+      -73.578787,
+      45.495078
+    ],
+    "floor": 1
+  },
+  "path-MBS2.104": {
+    "coordinates": [
+      -73.578766,
+      45.495086
+    ],
+    "floor": -2
+  },
+  "MBS2.129": {
+    "coordinates": [
+      -73.579412,
+      45.495314
+    ],
+    "floor": -2
+  },
+  "MB1.210": {
+    "coordinates": [
+      -73.578937,
+      45.495292
+    ],
+    "floor": 1
+  },
+  "MBS2.127": {
+    "coordinates": [
+      -73.579393,
+      45.495236
+    ],
+    "floor": -2
+  },
+  "MB1Escalator": {
+    "coordinates": [
+      -73.579066,
+      45.49539
+    ],
+    "floor": 1
+  },
+  "MB1.126": {
+    "coordinates": [
+      -73.579314,
+      45.495354
+    ],
+    "floor": 1
+  },
+  "MB1-entrance": {
+    "coordinates": [
+      -73.579213,
+      45.495495
+    ],
+    "floor": 1
+  },
+  "MBS2.107": {
+    "coordinates": [
+      -73.578811,
+      45.495084
+    ],
+    "floor": -2
+  },
+  "elevator1MBS2": {
+    "coordinates": [
+      -73.57905,
+      45.495277
+    ],
+    "floor": -2
+  },
+  "path-elevatorMB1": {
+    "coordinates": [
+      -73.579065,
+      45.495278
+    ],
+    "floor": 1
+  },
+  "path-MB1.210": {
+    "coordinates": [
+      -73.578708,
+      45.495159
+    ],
+    "floor": 1
+  },
+  "MB1.108": {
+    "coordinates": [
+      -73.579155,
+      45.49524
+    ],
+    "floor": 1
+  },
+  "path-MB1.128.2": {
+    "coordinates": [
+      -73.579236,
+      45.495435
+    ],
+    "floor": 1
+  },
+  "MB1.105": {
+    "coordinates": [
+      -73.579335,
+      45.495258
+    ],
+    "floor": 1
+  },
+  "path-MBS2.106": {
+    "coordinates": [
+      -73.578798,
+      45.495061
+    ],
+    "floor": -2
+  },
+  "path-MBS2.125": {
+    "coordinates": [
+      -73.579363,
+      45.495261
+    ],
+    "floor": -2
+  },
+  "path-MBS2.114": {
+    "coordinates": [
+      -73.579103,
+      45.495191
+    ],
+    "floor": -2
+  },
+  "escalatorMBS2": {
+    "coordinates": [
+      -73.578846,
+      45.495328
+    ],
+    "floor": -2
+  },
+  "path-stairs1MB1.3": {
+    "coordinates": [
+      -73.57868,
+      45.495181
+    ],
+    "floor": 1
+  },
+  "path-MB1.102": {
+    "coordinates": [
+      -73.578804,
+      45.495088
+    ],
+    "floor": 1
+  },
+  "MBS2.131": {
+    "coordinates": [
+      -73.57924,
+      45.495385
+    ],
+    "floor": -2
+  },
+  "path-MBS2.108": {
+    "coordinates": [
+      -73.578702,
+      45.495136
+    ],
+    "floor": -2
+  },
+  "MB1.132": {
+    "coordinates": [
+      -73.578824,
+      45.495064
+    ],
+    "floor": 1
+  },
+  "MBS2.105": {
+    "coordinates": [
+      -73.578759,
+      45.49504
+    ],
+    "floor": -2
+  },
+  "path-MB1.105": {
+    "coordinates": [
+      -73.579348,
+      45.495264
+    ],
+    "floor": 1
+  },
+  "MB1mbath": {
+    "coordinates": [
+      -73.579281,
+      45.495309
+    ],
+    "floor": 1
+  },
+  "MBS2.114": {
+    "coordinates": [
+      -73.579074,
+      45.495174
+    ],
+    "floor": -2
+  },
+  "path-MB1.210.2": {
+    "coordinates": [
+      -73.57896,
+      45.495302
+    ],
+    "floor": 1
+  },
+  "path-MB1.107": {
+    "coordinates": [
+      -73.579107,
+      45.495231
+    ],
+    "floor": 1
+  },
+  "stairs1MB1": {
+    "coordinates": [
+      -73.578924,
+      45.495303
+    ],
+    "floor": 1
+  },
+  "MBS2.125": {
+    "coordinates": [
+      -73.57929,
+      45.495219
+    ],
+    "floor": -2
+  },
+  "path-escalatorMBS2": {
+    "coordinates": [
+      -73.578647,
+      45.495179
+    ],
+    "floor": -2
+  },
+  "path-stairs1MB1": {
+    "coordinates": [
+      -73.578948,
+      45.495314
+    ],
+    "floor": 1
+  },
+  "stairs2MB": {
+    "coordinates": [
+      -73.579172,
+      45.49525
+    ],
+    "floor": 2
+  },
+  "path2-escalatorMBS2": {
+    "coordinates": [
+      -73.578624,
+      45.495197
+    ],
+    "floor": -2
+  },
+  "elevatorMB1": {
+    "coordinates": [
+      -73.579093,
+      45.49529
+    ],
+    "floor": 1
+  },
+  "MBS2.132": {
+    "coordinates": [
+      -73.579247,
+      45.495474
+    ],
+    "floor": -2
+  },
+  "path-MBS2.103": {
+    "coordinates": [
+      -73.57874,
+      45.495107
+    ],
+    "floor": -2
+  },
+  "path-MBS2.128": {
+    "coordinates": [
+      -73.579376,
+      45.495251
+    ],
+    "floor": -2
+  },
+  "PathToElevatorsMB1": {
+    "coordinates": [
+      -73.579019,
+      45.495331
+    ],
+    "floor": 1
+  },
+  "path-bathroom": {
+    "coordinates": [
+      -73.579291,
+      45.495325
+    ],
+    "floor": 0
+  },
+  "path-elevatorMBS2": {
+    "coordinates": [
+      -73.579017,
+      45.495259
+    ],
+    "floor": -2
+  },
+  "path-S2.130": {
+    "coordinates": [
+      -73.579289,
+      45.49532
+    ],
+    "floor": 2
+  },
+  "MB1.103": {
+    "coordinates": [
+      -73.578844,
+      45.495071
+    ],
+    "floor": 1
+  },
+  "path-MBS2.124": {
+    "coordinates": [
+      -73.579266,
+      45.495339
+    ],
+    "floor": -2
+  },
+  "path2-elevatorMBS2": {
+    "coordinates": [
+      -73.578961,
+      45.495305
+    ],
+    "floor": -2
+  },
+  "MB1.128": {
+    "coordinates": [
+      -73.579228,
+      45.495408
+    ],
+    "floor": 1
+  },
+  "path-MB1.108": {
+    "coordinates": [
+      -73.579147,
+      45.49525
+    ],
+    "floor": 1
+  },
+  "MBS2.106": {
+    "coordinates": [
+      -73.578812,
+      45.495049
+    ],
+    "floor": -2
+  },
+  "path_MBS2Stairs2": {
+    "coordinates": [
+      -73.578669,
+      45.495223
+    ],
+    "floor": -2
+  },
+  "MB1.107": {
+    "coordinates": [
+      -73.579118,
+      45.49522
+    ],
+    "floor": 1
+  },
+  "MB1.125": {
+    "coordinates": [
+      -73.579357,
+      45.495372
+    ],
+    "floor": 1
+  },
+  "path-MB1.126": {
+    "coordinates": [
+      -73.579275,
+      45.495393
+    ],
+    "floor": 1
+  },
+  "path-MBS2.129": {
+    "coordinates": [
+      -73.579348,
+      45.495275
+    ],
+    "floor": -2
+  },
+  "MB1.129": {
+    "coordinates": [
+      -73.579144,
+      45.495369
+    ],
+    "floor": 1
+  },
+  "path2-MBS2.133": {
+    "coordinates": [
+      -73.579162,
+      45.495423
+    ],
+    "floor": -2
+  },
+  "path-MB1.117": {
+    "coordinates": [
+      -73.579091,
+      45.495365
+    ],
+    "floor": 1
+  },
+  "path-stairs1MB1.2": {
+    "coordinates": [
+      -73.578934,
+      45.495328
+    ],
+    "floor": 1
+  },
+  "MBS2.108": {
+    "coordinates": [
+      -73.578715,
+      45.495143
+    ],
+    "floor": -2
+  },
+  "MBS2Stairs2": {
+    "coordinates": [
+      -73.578644,
+      45.495243
+    ],
+    "floor": -2
+  },
+  "MBS2.133": {
+    "coordinates": [
+      -73.579188,
+      45.495463
+    ],
+    "floor": -2
+  },
+  "path-MBS2.126": {
+    "coordinates": [
+      -73.579306,
+      45.495307
+    ],
+    "floor": -2
+  },
+  "MBS2.124": {
+    "coordinates": [
+      -73.579213,
+      45.495308
+    ],
+    "floor": -2
+  },
+  "MBS2.126": {
+    "coordinates": [
+      -73.579274,
+      45.495291
+    ],
+    "floor": -2
+  },
+  "path-MBS2.133": {
+    "coordinates": [
+      -73.579205,
+      45.495448
+    ],
+    "floor": -2
+  },
+  "path-MB1.129": {
+    "coordinates": [
+      -73.579131,
+      45.495385
+    ],
+    "floor": 1
+  },
+  "MBS2Stairs1": {
+    "coordinates": [
+      -73.579145,
+      45.495202
+    ],
+    "floor": -2
+  },
+  "MB1.117": {
+    "coordinates": [
+      -73.579106,
+      45.49535
+    ],
+    "floor": 1
+  },
+  "MBS2.130": {
+    "coordinates": [
+      -73.579305,
+      45.495329
+    ],
+    "floor": -2
+  },
+  "path-MBS2.107": {
+    "coordinates": [
+      -73.578786,
+      45.49507
+    ],
+    "floor": -2
+  },
+  "MB1wbath": {
+    "coordinates": [
+      -73.579265,
+      45.495325
+    ],
+    "floor": 1
+  },
+  "MBS2.128": {
+    "coordinates": [
+      -73.57941,
+      45.495269
+    ],
+    "floor": -2
+  },
+  "MBS2.103": {
+    "coordinates": [
+      -73.578704,
+      45.495083
+    ],
+    "floor": -2
+  },
+  "path-MB1.127": {
+    "coordinates": [
+      -73.579242,
+      45.495377
+    ],
+    "floor": 1
+  },
+  "path-bathrrom2": {
+    "coordinates": [
+      -73.579273,
+      45.495316
+    ],
+    "floor": 2
+  },
+  "path-MBS2.131": {
+    "coordinates": [
+      -73.579223,
+      45.495373
+    ],
+    "floor": -2
+  },
+  "MB1.124": {
+    "coordinates": [
+      -73.57936,
+      45.49527
+    ],
+    "floor": 1
+  },
+  "MB1.101": {
+    "coordinates": [
+      -73.578679,
+      45.495142
+    ],
+    "floor": 1
+  },
+  "path3-elevatorMBS2": {
+    "coordinates": [
+      -73.578915,
+      45.495339
+    ],
+    "floor": -2
+  },
+  "MBS2.113": {
+    "coordinates": [
+      -73.579024,
+      45.495186
+    ],
+    "floor": -2
+  },
+  "path-MB1.128": {
+    "coordinates": [
+      -73.579254,
+      45.495418
+    ],
+    "floor": 1
+  },
+  "MBS2.104": {
+    "coordinates": [
+      -73.578731,
+      45.495063
+    ],
+    "floor": -2
+  }
+}

--- a/myApp/app/components/IndoorMap/ShortestPath.js
+++ b/myApp/app/components/IndoorMap/ShortestPath.js
@@ -28,7 +28,7 @@ export function dijkstra(graph, startNode, endNode, isDisabled) {
     // Stop if we reach the end node
     if (currentNode === endNode) break;
 
-    // for each neighbour of our current node, check if going through currentNode provides a shorter path
+    // for each neighbour of our current node (connected_tos), check if going through currentNode provides a shorter path
     for (let neighbor in graph[currentNode]) {
       if (
         isDisabled && 

--- a/myApp/app/components/IndoorMap/ShortestPath.js
+++ b/myApp/app/components/IndoorMap/ShortestPath.js
@@ -1,30 +1,48 @@
-export function dijkstra(graph, startNode, endNode) {
+export function dijkstra(graph, startNode, endNode, isDisabled) {
+  // this keeps of the distance from the start node to every other node 
   let distances = {};
+  // stores the previous node leading to the shortest path
   let previousNodes = {};
+  // keeps track of nodes that have not been visited yet. initialised with all nodes in the graph
   let unvisitedNodes = new Set(Object.keys(graph));
 
   // Initialize distances and previous nodes
   for (let node of unvisitedNodes) {
+    // initially, all nodes have a distance of infinity
     distances[node] = Infinity;
+    // initialy, every nodes previous node is null
     previousNodes[node] = null;
   }
   distances[startNode] = 0;
 
+  // while there are still univisited nodes
   while (unvisitedNodes.size > 0) {
-    // Get the node with the smallest distance
+    // Get the node with the smallest distance by using .reduce(). Ensures that we always expand the shortest known path
     let currentNode = [...unvisitedNodes].reduce((a, b) =>
       distances[a] < distances[b] ? a : b, null
     );
 
+    // this removes the current Node from the unvisited nodes
     unvisitedNodes.delete(currentNode);
 
     // Stop if we reach the end node
     if (currentNode === endNode) break;
 
+    // for each neighbour of our current node, check if going through currentNode provides a shorter path
     for (let neighbor in graph[currentNode]) {
+      if (
+        isDisabled && 
+        (neighbor.includes("stair") || neighbor.includes("escalator")) && 
+        !(neighbor.includes("path") || neighbor.includes("elevator"))
+      ) {
+        console.log(neighbor)
+        continue; // Skip this neighbor
+      }
       let weight = graph[currentNode][neighbor];
       let newDistance = distances[currentNode] + weight;
 
+      // if new distance is shorter than existing record, replace it. 
+      // new distance is from startNode -> currentNode -> neighbour
       if (newDistance < distances[neighbor]) {
         distances[neighbor] = newDistance;
         previousNodes[neighbor] = currentNode;
@@ -32,7 +50,7 @@ export function dijkstra(graph, startNode, endNode) {
     }
   }
 
-  // Reconstruct shortest path
+  // Reconstruct shortest path, going backwards
   let path = [];
   let currentNode = endNode;
   while (currentNode) {

--- a/myApp/app/components/IndoorMap/ShortestPath.js
+++ b/myApp/app/components/IndoorMap/ShortestPath.js
@@ -30,6 +30,8 @@ export function dijkstra(graph, startNode, endNode, isDisabled) {
 
     // for each neighbour of our current node (connected_tos), check if going through currentNode provides a shorter path
     for (let neighbor in graph[currentNode]) {
+      // conditional only skips node if it continues stair or escalator without including path or elevator in its id
+      // this is because some of our nodes that lead to elevator might also lead to stairs or escalators
       if (
         isDisabled && 
         (neighbor.includes("stair") || neighbor.includes("escalator")) && 

--- a/myApp/app/components/IndoorMap/ShortestPath.js
+++ b/myApp/app/components/IndoorMap/ShortestPath.js
@@ -6,6 +6,19 @@ export function dijkstra(graph, startNode, endNode, isDisabled) {
   // keeps track of nodes that have not been visited yet. initialised with all nodes in the graph
   let unvisitedNodes = new Set(Object.keys(graph));
 
+  // check to see if user requires disabled friendly directions (no stairs, no escalators, only elevators)
+  const shouldSkipNeighbour = (disabled, neighbouringNode) => {
+    if(disabled && 
+      (neighbouringNode.includes("stair") || neighbouringNode.includes("escalator")) && 
+      !(neighbouringNode.includes("path") || neighbouringNode.includes("elevator")))
+      {
+        return true;
+      }
+    else{
+      return false;
+    }
+  }
+
   // Initialize distances and previous nodes
   for (let node of unvisitedNodes) {
     // initially, all nodes have a distance of infinity
@@ -29,25 +42,21 @@ export function dijkstra(graph, startNode, endNode, isDisabled) {
     if (currentNode === endNode) break;
 
     // for each neighbour of our current node (connected_tos), check if going through currentNode provides a shorter path
-    for (let neighbor in graph[currentNode]) {
+    for (let neighbour in graph[currentNode]) {
       // conditional only skips node if it continues stair or escalator without including path or elevator in its id
       // this is because some of our nodes that lead to elevator might also lead to stairs or escalators
-      if (
-        isDisabled && 
-        (neighbor.includes("stair") || neighbor.includes("escalator")) && 
-        !(neighbor.includes("path") || neighbor.includes("elevator"))
-      ) {
-        console.log(neighbor)
-        continue; // Skip this neighbor
+      if (shouldSkipNeighbour(isDisabled, neighbour)) {
+        console.log(neighbour)
+        continue; // Skip this neighbour
       }
-      let weight = graph[currentNode][neighbor];
+      let weight = graph[currentNode][neighbour];
       let newDistance = distances[currentNode] + weight;
 
       // if new distance is shorter than existing record, replace it. 
       // new distance is from startNode -> currentNode -> neighbour
-      if (newDistance < distances[neighbor]) {
-        distances[neighbor] = newDistance;
-        previousNodes[neighbor] = currentNode;
+      if (newDistance < distances[neighbour]) {
+        distances[neighbour] = newDistance;
+        previousNodes[neighbour] = currentNode;
       }
     }
   }

--- a/myApp/app/components/IndoorMap/ShortestPath.js
+++ b/myApp/app/components/IndoorMap/ShortestPath.js
@@ -1,13 +1,7 @@
 export function dijkstra(graph, startNode, endNode, isDisabled) {
-  // this keeps of the distance from the start node to every other node 
-  let distances = {};
-  // stores the previous node leading to the shortest path
-  let previousNodes = {};
-  // keeps track of nodes that have not been visited yet. initialised with all nodes in the graph
-  let unvisitedNodes = new Set(Object.keys(graph));
 
   // check to see if user requires disabled friendly directions (no stairs, no escalators, only elevators)
-  const shouldSkipNeighbour = (disabled, neighbouringNode) => {
+  const shouldSkipNode = (disabled, neighbouringNode) => {
     if(disabled && 
       (neighbouringNode.includes("stair") || neighbouringNode.includes("escalator")) && 
       !(neighbouringNode.includes("path") || neighbouringNode.includes("elevator")))
@@ -18,6 +12,28 @@ export function dijkstra(graph, startNode, endNode, isDisabled) {
       return false;
     }
   }
+
+  // check to see if start or end node is inacessible for someone who is disabled
+  const startOrEndNodeInaccessible = (startNode, endNode, disabled) => {
+    if (shouldSkipNode(disabled, startNode)){
+      return true;
+    }
+    else if (shouldSkipNode(disabled, endNode)){
+      return true;
+    }
+    else return false;
+  }
+
+  if (startOrEndNodeInaccessible(startNode, endNode, isDisabled)){
+    return null;
+  }
+
+  // this keeps of the distance from the start node to every other node 
+  let distances = {};
+  // stores the previous node leading to the shortest path
+  let previousNodes = {};
+  // keeps track of nodes that have not been visited yet. initialised with all nodes in the graph
+  let unvisitedNodes = new Set(Object.keys(graph));
 
   // Initialize distances and previous nodes
   for (let node of unvisitedNodes) {
@@ -45,7 +61,7 @@ export function dijkstra(graph, startNode, endNode, isDisabled) {
     for (let neighbour in graph[currentNode]) {
       // conditional only skips node if it continues stair or escalator without including path or elevator in its id
       // this is because some of our nodes that lead to elevator might also lead to stairs or escalators
-      if (shouldSkipNeighbour(isDisabled, neighbour)) {
+      if (shouldSkipNode(isDisabled, neighbour)) {
         console.log(neighbour)
         continue; // Skip this neighbour
       }

--- a/myApp/app/components/IndoorMap/ShortestPathMap.js
+++ b/myApp/app/components/IndoorMap/ShortestPathMap.js
@@ -7,14 +7,14 @@ import PropTypes from 'prop-types';
 Mapbox.setAccessToken("sk.eyJ1IjoiN2FuaW5lIiwiYSI6ImNtN3F3ZWhoZjBjOGIya3NlZjc5aWc2NmoifQ.7bRiuJDphvZiBmpK26lkQw");
 
 //Algorithm only renders the floor that you are currently on. Splits paths into different floors.
-const ShortestPathMap = ({ graph, nodeCoordinates, startNode, endNode, currentFloor }) => {
+const ShortestPathMap = ({ graph, nodeCoordinates, startNode, endNode, currentFloor, isDisabled }) => {
   const [floorPaths, setFloorPaths] = useState({}); // Store paths for multiple floors
 
   useEffect(() => {
     if (!startNode || !endNode || !nodeCoordinates) return;
 
     // Find shortest path using Dijkstra's algorithm
-    const shortestPathNodes = dijkstra(graph, startNode, endNode);
+    const shortestPathNodes = dijkstra(graph, startNode, endNode, isDisabled);
 
     if (shortestPathNodes) {
       const pathsByFloor = {}; // Store paths for each floor


### PR DESCRIPTION
#### Feature
- useState added in the code: isDisabled
- if it is set to true, only considers paths that lead to elevators
- Also refactored graph and coordinate files to split them so that it is easier to change them individually in the future 
        - will wait before deleting old file

#### Tests
- automated tests
- manual tests

#### How to test PR:
Hall: H919 to H827
VL: VL109 to VL209

#### Expected output
(Please note that for whatever reason, the nodes between the graphs are not properly linked to neighbors and is why the routes sometimes go in diagonal as can be seen on the screenshots. This is a known limitation that will be fixed in another PR to come. It will just have to be a PR fixing the problems with our graphs.)
For Hall:
<img width="365" alt="Screenshot 2025-03-17 at 6 37 16 PM" src="https://github.com/user-attachments/assets/c767abbf-a2a7-4654-b5f1-30e70dcd22f2" />

<img width="372" alt="Screenshot 2025-03-17 at 6 37 22 PM" src="https://github.com/user-attachments/assets/e75fdbbc-1279-4590-a0e0-27d2cf4c978b" />

For VL:
<img width="370" alt="Screenshot 2025-03-17 at 6 36 40 PM" src="https://github.com/user-attachments/assets/2463333d-9975-4ea8-8675-a6625ee55d6c" />
<img width="375" alt="Screenshot 2025-03-17 at 6 36 46 PM" src="https://github.com/user-attachments/assets/8d4b1218-f0da-4291-98f4-919be6a47ab5" />

