### PR TITLE
Fix: Implement cross-platform dropdown for month selection in Calendar Fetching screen

### DIFF
--- a/myApp/app/__tests__/CalendarFetching.test.js
+++ b/myApp/app/__tests__/CalendarFetching.test.js
@@ -132,3 +132,19 @@ describe('CalendarFetching Component', () => {
 
 
 });
+
+test('renders calendar history box with stored calendar IDs', async () => {
+  const AsyncStorage = require('@react-native-async-storage/async-storage');
+  AsyncStorage.getItem.mockResolvedValue(
+    JSON.stringify([
+      { id: 'calendar-1', name: 'Work Calendar' },
+      { id: 'calendar-2', name: 'Personal Calendar' },
+    ])
+  );
+
+  const { findByText } = renderWithNav(<CalendarFetching />);
+
+  // Check that history items are rendered in the box
+  expect(await findByText('Work Calendar')).toBeTruthy();
+  expect(await findByText('Personal Calendar')).toBeTruthy();
+});

--- a/myApp/app/components/MonthPicker.js
+++ b/myApp/app/components/MonthPicker.js
@@ -1,35 +1,81 @@
-import { Picker } from '@react-native-picker/picker';
-import React from 'react';
-import { View, Text } from 'react-native';
+// import { Picker } from '@react-native-picker/picker';
+// import React from 'react';
+// import { View, Text } from 'react-native';
 
-const MonthPicker = ({ monthsAhead, setMonthsAhead, styles }) => (
-  <View style={{ marginTop: 10 }}>
-    <Text style={styles.subtitle}>Show events for the upcoming:</Text>
-    <View
-      style={{
-        borderWidth: 1,
-        borderColor: '#ccc',
-        borderRadius: 6,
-        overflow: 'hidden',
-        marginBottom: 10,
-      }}
-    >
-      <Picker
-        selectedValue={monthsAhead}
-        onValueChange={(itemValue) => setMonthsAhead(itemValue)}
-        style={{ height: 50 }}
-        testID="month-picker"
-      >
-        <Picker.Item label="1 Month" value="1" />
-        <Picker.Item label="2 Months" value="2" />
-        <Picker.Item label="3 Months" value="3" />
-        <Picker.Item label="4 Months" value="4" />
-        <Picker.Item label="5 Months" value="5" />
-        <Picker.Item label="6 Months" value="6" />
-        <Picker.Item label="All Events" value="all" />
-      </Picker>
+// const MonthPicker = ({ monthsAhead, setMonthsAhead, styles }) => (
+//   <View style={{ marginTop: 10 }}>
+//     <Text style={styles.subtitle}>Show events for the upcoming:</Text>
+//     <View
+//       style={{
+//         borderWidth: 1,
+//         borderColor: '#ccc',
+//         borderRadius: 6,
+//         overflow: 'hidden',
+//         marginBottom: 10,
+//       }}
+//     >
+//       <Picker
+//         selectedValue={monthsAhead}
+//         onValueChange={(itemValue) => setMonthsAhead(itemValue)}
+//         style={{ height: 50 }}
+//         testID="month-picker"
+//       >
+//         <Picker.Item label="1 Month" value="1" />
+//         <Picker.Item label="2 Months" value="2" />
+//         <Picker.Item label="3 Months" value="3" />
+//         <Picker.Item label="4 Months" value="4" />
+//         <Picker.Item label="5 Months" value="5" />
+//         <Picker.Item label="6 Months" value="6" />
+//         <Picker.Item label="All Events" value="all" />
+//       </Picker>
+//     </View>
+//   </View>
+// );
+
+// export default MonthPicker;
+import React, { useState, useEffect } from "react";
+import DropDownPicker from "react-native-dropdown-picker";
+import { View, Text } from "react-native";
+
+const MonthPicker = ({ monthsAhead, setMonthsAhead, styles }) => {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState(monthsAhead);
+  const [items, setItems] = useState([
+    { label: "1 Month", value: "1" },
+    { label: "2 Months", value: "2" },
+    { label: "3 Months", value: "3" },
+    { label: "4 Months", value: "4" },
+    { label: "5 Months", value: "5" },
+    { label: "6 Months", value: "6" },
+    { label: "All Events", value: "all" },
+  ]);
+
+  // Update parent state when dropdown changes
+  useEffect(() => {
+    setMonthsAhead(value);
+  }, [value]);
+
+  return (
+    <View style={{ zIndex: 1000, marginBottom: open ? 160 : 30 }}>
+      <Text style={styles.subtitle}>Show events for the upcoming:</Text>
+      <DropDownPicker
+        open={open}
+        value={value}
+        items={items}
+        setOpen={setOpen}
+        setValue={setValue}
+        setItems={setItems}
+        placeholder="Select a time range"
+        style={{
+          borderColor: "#ccc",
+          backgroundColor: "#fff",
+        }}
+        dropDownContainerStyle={{
+          borderColor: "#ccc",
+        }}
+      />
     </View>
-  </View>
-);
+  );
+};
 
 export default MonthPicker;

--- a/myApp/app/components/MonthPicker.js
+++ b/myApp/app/components/MonthPicker.js
@@ -1,38 +1,3 @@
-// import { Picker } from '@react-native-picker/picker';
-// import React from 'react';
-// import { View, Text } from 'react-native';
-
-// const MonthPicker = ({ monthsAhead, setMonthsAhead, styles }) => (
-//   <View style={{ marginTop: 10 }}>
-//     <Text style={styles.subtitle}>Show events for the upcoming:</Text>
-//     <View
-//       style={{
-//         borderWidth: 1,
-//         borderColor: '#ccc',
-//         borderRadius: 6,
-//         overflow: 'hidden',
-//         marginBottom: 10,
-//       }}
-//     >
-//       <Picker
-//         selectedValue={monthsAhead}
-//         onValueChange={(itemValue) => setMonthsAhead(itemValue)}
-//         style={{ height: 50 }}
-//         testID="month-picker"
-//       >
-//         <Picker.Item label="1 Month" value="1" />
-//         <Picker.Item label="2 Months" value="2" />
-//         <Picker.Item label="3 Months" value="3" />
-//         <Picker.Item label="4 Months" value="4" />
-//         <Picker.Item label="5 Months" value="5" />
-//         <Picker.Item label="6 Months" value="6" />
-//         <Picker.Item label="All Events" value="all" />
-//       </Picker>
-//     </View>
-//   </View>
-// );
-
-// export default MonthPicker;
 import React, { useState, useEffect } from "react";
 import DropDownPicker from "react-native-dropdown-picker";
 import { View, Text } from "react-native";

--- a/myApp/app/index.js
+++ b/myApp/app/index.js
@@ -1,7 +1,12 @@
-import { View } from "react-native";
+import { LogBox, View } from "react-native";
 import React from "react";
 import HomePage from "./screens/HomePage";
 import 'react-native-get-random-values';
+
+LogBox.ignoreLogs([
+  'VirtualizedLists should never be nested',
+]);
+
 
 export default function Index() {
 

--- a/myApp/app/screens/CalendarFetching.js
+++ b/myApp/app/screens/CalendarFetching.js
@@ -163,8 +163,8 @@ export default function CalendarFetching() {
         {/* Header */}
         <HeaderButtons />
         {/* Events Scroll */}
-        <ScrollView 
-          contentContainerStyle={{ flexGrow: 1 }} 
+        <ScrollView
+          contentContainerStyle={{ flexGrow: 1 }}
           keyboardShouldPersistTaps="handled"
           enableOnAndroid={true}
           extraScrollHeight={20}
@@ -184,23 +184,29 @@ export default function CalendarFetching() {
                 />
 
                 {/* Calendar History */}
-                {storedCalendarIds.length > 0 && (
-                  <View style={{ marginTop: 10 }}>
-                    <Text style={styles.subtitle}>Calendars History:</Text>
-                    {storedCalendarIds.map((item, index) => (
-                      <TouchableOpacity
-                        key={index}
-                        style={styles.historyItem}
-                        onPress={() => setCalendarId(item.id)}
-                      >
-                        <View style={{ flexDirection: "row", alignItems: "center" }}>
-                          <Ionicons name="timer-outline" size={20} color="#888" style={{ marginRight: 6 }} />
-                          <Text style={styles.historyText}>{item.name}</Text>
-                        </View>
-                      </TouchableOpacity>
-                    ))}
+                <View style={{ marginTop: 10 }}>
+                  <Text style={styles.subtitle}>Calendars History:</Text>
+                  <View style={{ height: 100, borderWidth: 1, borderColor: '#ccc', borderRadius: 8, padding: 5 }}>
+                    {storedCalendarIds.length === 0 ? (
+                      <Text style={{ color: '#888', fontStyle: 'italic' }}>No history yet.</Text>
+                    ) : (
+                      <ScrollView>
+                        {storedCalendarIds.map((item, index) => (
+                          <TouchableOpacity
+                            key={index}
+                            style={styles.historyItem}
+                            onPress={() => setCalendarId(item.id)}
+                          >
+                            <View style={{ flexDirection: "row", alignItems: "center" }}>
+                              <Ionicons name="timer-outline" size={20} color="#888" style={{ marginRight: 6 }} />
+                              <Text style={styles.historyText}>{item.name}</Text>
+                            </View>
+                          </TouchableOpacity>
+                        ))}
+                      </ScrollView>
+                    )}
                   </View>
-                )}
+                </View>
 
                 {/* Months Ahead Input */}
                 <View style={{ marginTop: 10 }}>

--- a/myApp/app/screens/CalendarFetching.js
+++ b/myApp/app/screens/CalendarFetching.js
@@ -24,6 +24,7 @@ import HeaderButtons from "../components/HeaderButtons.js";
 import MonthPicker from '../components/MonthPicker';
 
 
+
 export default function CalendarFetching() {
   const navigation = useNavigation();
   const router = useRouter();
@@ -162,7 +163,11 @@ export default function CalendarFetching() {
         {/* Header */}
         <HeaderButtons />
         {/* Events Scroll */}
-        <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
+        <ScrollView 
+          contentContainerStyle={{ flexGrow: 1 }} 
+          keyboardShouldPersistTaps="handled"
+        >
+
           <View style={styles.container}>
             <View style={styles.redContainer}>
               <View style={styles.whiteContainer}>

--- a/myApp/app/screens/CalendarFetching.js
+++ b/myApp/app/screens/CalendarFetching.js
@@ -166,6 +166,8 @@ export default function CalendarFetching() {
         <ScrollView 
           contentContainerStyle={{ flexGrow: 1 }} 
           keyboardShouldPersistTaps="handled"
+          enableOnAndroid={true}
+          extraScrollHeight={20}
         >
 
           <View style={styles.container}>

--- a/myApp/app/styles/CalendarFetchingStyles.js
+++ b/myApp/app/styles/CalendarFetchingStyles.js
@@ -53,6 +53,8 @@ export const calendarFetchingStyles = StyleSheet.create({
     alignSelf: 'center',
     minWidth: 100,
     paddingHorizontal: 20,
+    position: 'absolute',
+    bottom: 55,
   },
   buttonText: {
     color: 'white',
@@ -117,7 +119,7 @@ export const calendarFetchingStyles = StyleSheet.create({
     borderRadius: 10,
     padding: 10,
     marginBottom: 10,
-    paddingVertical: 12,
+    paddingVertical: 5,
   },
   historyText: {
     fontSize: 10,
@@ -136,6 +138,8 @@ export const calendarFetchingStyles = StyleSheet.create({
     borderColor: '#ccc',
     alignSelf: 'center',
     marginTop: 10,
+    position: 'absolute',
+    bottom: 10,
   },
   clearHistoryText: {
     fontSize: FONT_SIZE_1,

--- a/myApp/package-lock.json
+++ b/myApp/package-lock.json
@@ -55,6 +55,7 @@
         "react-dom": "^18.3.1",
         "react-native": "0.76.6",
         "react-native-config": "^1.5.5",
+        "react-native-dropdown-picker": "^5.4.6",
         "react-native-geolocation-service": "^5.3.1",
         "react-native-gesture-handler": "~2.20.2",
         "react-native-get-random-values": "^1.11.0",
@@ -12813,6 +12814,16 @@
         "react-native-windows": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-dropdown-picker": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/react-native-dropdown-picker/-/react-native-dropdown-picker-5.4.6.tgz",
+      "integrity": "sha512-T1XBHbE++M6aRU3wFYw3MvcOuabhWZ29RK/Ivdls2r1ZkZ62iEBZknLUPeVLMX3x6iUxj4Zgr3X2DGlEGXeHsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-geolocation-service": {

--- a/myApp/package.json
+++ b/myApp/package.json
@@ -70,6 +70,7 @@
     "react-dom": "^18.3.1",
     "react-native": "0.76.6",
     "react-native-config": "^1.5.5",
+    "react-native-dropdown-picker": "^5.4.6",
     "react-native-geolocation-service": "^5.3.1",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-get-random-values": "^1.11.0",


### PR DESCRIPTION
This PR replaces the native Picker component with `react-native-dropdown-picker` to ensure consistent UI/UX for month selection across both Android and iOS platforms. 

## Changes

- Replaced native Picker with cross-platform dropdown in `MonthPicker.js`
- Updated `CalendarFetching.js` to integrate and display the new MonthPicker properly
- Adjusted styling and layout for proper dropdown rendering and interaction
- Added `keyboardShouldPersistTaps="handled"` to ScrollView to prevent tap issues on iOS

## Why

The previous month selector did not render visibly or interactively on iOS. This change ensures that users on both platforms can select how many months of events to fetch from their calendar.


Before:
<p align="center">
  <strong></strong><br/>
  <img src="https://github.com/user-attachments/assets/887f4a1e-011b-41ed-a8f3-7e1ac365e621" alt="Before" width="300"/>
</p>


After:

<p align="center">
  <strong></strong><br/>
  <img src="https://github.com/user-attachments/assets/1b84f03f-4dfd-4458-b874-2470eaf0712b" alt="Screenshot 1" width="300"/>
</p>

<p align="center">
  <strong></strong><br/>
  <img src="https://github.com/user-attachments/assets/739a03ac-9cf5-4be3-ab2e-97f4a70250e4" alt="Screenshot 2" width="300"/>
</p>

