### PR TITLE
Added logic so that polylines cannot be rendered if there is no shuttle

### DIFF
--- a/myApp/app/(tabs)/map.jsx
+++ b/myApp/app/(tabs)/map.jsx
@@ -266,12 +266,8 @@ useEffect(() => {
         updateDestination(newDestination, destinationText);
       }
       
-      //these two things above are not what is crashing the app
       if (
-        originText == "My Location" &&
-        (destinationText == "Loyola Campus, Shuttle Stop" ||
-          destinationText == "SGW Campus, Shuttle Stop") &&
-        renderMap
+        origin && (destinationText == "Loyola Campus, Shuttle Stop" || destinationText == "SGW Campus, Shuttle Stop") && renderMap
       ) {
         updateShowShuttleRoute(true);
       } else {
@@ -616,17 +612,19 @@ useEffect(() => {
     console.log("Shuttle button click");
 
     // Update origin & destination as before
-    updateOrigin(coordinatesMap["My Position"], "My Location");
-    if (activeCampus === "sgw") {
-      updateDestination(
-        coordinatesMap["Loyola Campus, Shuttle Stop"],
-        "Loyola Campus, Shuttle Stop"
-      );
-    } else {
-      updateDestination(
-        coordinatesMap["SGW Campus, Shuttle Stop"],
-        "SGW Campus, Shuttle Stop"
-      );
+    if (shuttleDetails && !shuttleDetails.error){
+      updateOrigin(coordinatesMap["My Position"], "My Location");
+      if (activeCampus === "sgw") {
+        updateDestination(
+          coordinatesMap["Loyola Campus, Shuttle Stop"],
+          "Loyola Campus, Shuttle Stop"
+        );
+      } else {
+        updateDestination(
+          coordinatesMap["SGW Campus, Shuttle Stop"],
+          "SGW Campus, Shuttle Stop"
+        );
+      }
     }
 
     try {


### PR DESCRIPTION
This is a tiny add on to the bug report fix in #336 

### Feature
- added extra conditional for when originText and destinationText are updated after clicking button for shuttle

### Before fix:
- origin and destination are set even thought there are no shuttles
<img width="358" alt="Screenshot 2025-03-28 at 10 43 13 PM" src="https://github.com/user-attachments/assets/d9cd1e29-0b7f-4e2b-ad01-60bb7d40c98d" />

### Post fix
- origin and destination not set when there are no shuttles
<img width="367" alt="Screenshot 2025-03-28 at 10 42 47 PM" src="https://github.com/user-attachments/assets/6d02d7de-a07b-4e87-a0d8-6f23621f5569" />
